### PR TITLE
Check for missing authentication header

### DIFF
--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -59,7 +59,18 @@ class HttpActions {
             me.debug('HttpActions:httpActionsRegister(/smarthome): request.headers.authorization = ' + request.headers.authorization);
             me.debug('HttpActions:httpActionsRegister(/smarthome): reqdata = ' + JSON.stringify(reqdata));
             
-            let res = request.headers.authorization.split(" ");
+            let res = request.headers.authorization;
+            if (!res) {
+                me.debug('HttpActions:httpActionsRegister(/smarthome): missing authorization header; res = ' + JSON.stringify(res));
+
+                response.status(401).set({
+                    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+                }).json({error: 'missing inputs'});
+
+                return;
+            }
+
+            res.split(" ");
             if (res.length != 2 || res[0] != 'Bearer') {
                 me.debug('HttpActions:httpActionsRegister(/smarthome): invalid authorization data; res = ' + JSON.stringify(res));
 


### PR DESCRIPTION
When somebody sends a POST request without authorization header to the /smarthome endpoint, it prints an error message ("Cannot read property 'split' of undefined") including a full stacktrace. Since a few days somebody tries to scan my home. This fills my log pretty quick with useless stacktraces.