### PR TITLE
Add window as supported device

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,28 @@ If `topic` is something else then `payload` must be an object and tells both the
           online: true
         }
 
+#### - Window
+`topic` can be `openPercent`, `online` or something else.
+
+If `topic` is `openPercent` then `payload` must be integer and indicates the percentage that the window is opened where 0 is closed and 100 is fully open.
+
+        msg.topic = 'openPercent'
+        msg.payload = 50
+
+
+If `topic` is `online` then `payload` must be boolean and tells the online state of the window.
+
+        msg.topic = 'online'
+        msg.payload = true
+
+If `topic` is something else then `payload` must be an object and tells both the open state as well as the online state of the window.
+
+        msg.topic = 'set'
+        msg.payload = {
+          openPercent: false,
+          online: true
+        }
+
 #### - Scene
 Messages sent to this node is simply passed through. One cannot tell Google SmartHome to activate a scene, they tell us.
 

--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -91,6 +91,10 @@ module.exports = function(RED) {
                     states = node.app.NewScene(client, name, param1);
                     break;
 
+                case 'window':
+                    states = node.app.NewWindow(client, name);
+                    break;
+
                 case 'mgmt':
                     node.mgmtNodes[client.id] = client;
                     break;

--- a/lib/Devices.js
+++ b/lib/Devices.js
@@ -337,6 +337,52 @@ class Devices {
     //
     //
     //
+    NewWindow(client, name) {
+        this.debug('Devices:NewWindow(): BEGIN');
+
+        let states = {
+            online: true,
+            openPercent: false
+        };
+
+        let device = {
+            id: client.id,
+            properties: {
+                type: 'action.devices.types.WINDOW',
+                traits: [ 'action.devices.traits.OpenClose' ],
+                name: {
+                    defaultNames: ["Node-RED Window"],
+                    name: name
+                },
+                willReportState: true,
+                attributes: {
+                },
+                deviceInfo: {
+                    manufacturer: 'Node-RED',
+                    model: 'nr-window-v1',
+                    swVersion: '1.0',
+                    hwVersion: '1.0'
+                },
+                customData: {
+                    "nodeid": client.id,
+                    "type": 'window'
+                }
+            }
+        };
+
+        device.states = states;
+
+        if (this.registerDevice(client, device)) {
+            this.debug('Devices:NewWindow(): END ok');
+            return JSON.parse(JSON.stringify(states));
+        } else {
+            this.debug('Devices:NewWindow(): END fail');
+            return {};
+        }
+    }
+    //
+    //
+    //
     DeleteDevice(client) {
         if (!this._devices[client.id]) {
             this.debug('Device:registerDevice(): device does not exist; client.id = ' + client.id);

--- a/locales/en-US/window.json
+++ b/locales/en-US/window.json
@@ -1,0 +1,16 @@
+{
+    "window": {
+        "label": {
+            "name": "Name",
+            "topic": "Out topic"
+        },
+        "placeholder": {
+            "name": "Name",
+            "topic": "Outgoing topic"
+        },
+        "errors": {
+            "missing-config": "Missing SmartHome configuration",
+            "missing-bridge": "Missing SmartHome"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-google-smarthome",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Google SmartHome",
   "main": "google-smarthome.js",
   "scripts": {},
@@ -19,7 +19,8 @@
       "google-smarthome": "google-smarthome.js",
       "light": "light.js",
       "outlet": "outlet.js",
-      "scene": "scene.js"
+      "scene": "scene.js",
+      "window": "window.js"
     }
   },
   "author": {

--- a/window.html
+++ b/window.html
@@ -1,0 +1,163 @@
+<!--
+ NodeRED Google SmartHome
+ Copyright (C) 2018 Michael Jacobsen.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!--
+    Window
+-->
+<script type="text/x-red" data-template-name="google-window">
+    <div class="form-row">
+        <b>Google SmartHome Settings</b>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-client"><i class="fa fa-globe"></i> SmartHome</span></label>
+        <input type="text" id="node-input-client">
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="window.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]window.placeholder.name">
+    </div>
+
+    <div class="form-row">
+        <b>Node-RED Settings</b>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-topic"><i class="fa fa-tasks"></i> <span data-i18n="window.label.topic"></span></label>
+        <input type="text" id="node-input-topic" data-i18n="[placeholder]window.placeholder.topic">
+    </div>
+
+    <div class="form-row">
+        <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
+        <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="google-window">
+    <p>A Google Smart Home Window. Outputs a message when Google Smart Home changes the state of the window.</p>
+
+    <h3>Inputs</h3>
+        <dl class="message-properties">
+            <dt>payload
+                <span class="property-type">integer | object</span>
+            </dt>
+            <dd>state to send to Google Smart Home.</dd>
+        </dl>
+    
+     <h3>Output</h3>
+        <dl class="message-properties">
+            <dt>payload
+                <span class="property-type">object</span>
+            </dt>
+            <dd>state received from Google Smart Home.</dd>
+        </dl>
+    
+    <h3>Details</h3>
+        <h4>Node Properties - Google SmartHome Settings</h4>
+        <p><code>SmartHome</code> Configuration node.</p>
+        <p><code>Name</code> Name used by Google Smart Home.</p>
+        <h4>Node Properties - Node-RED Settings</h4>
+        <p><code>Out topic</code> Topic used by this node when sending updates from Google Smart Home.</p>
+        <p><code>Pass Through</code> If enabled, incoming messages will be passed onto the output. Be carefull with this setting.</p>
+
+        <h4>Input Messages</h4>
+        <p>If <code>msg.topic</code> is <code>openPercent</code> then <code>msg.payload</code> must be integer and indicates the percentage that the window is opened where 0 is closed and 100 is fully open.</p>
+        <dl class="message-properties">
+            <dt>payload
+                <span class="property-type">integer</span>
+            </dt>
+            <dd>Value is the percentage that the window is opened where <code>0</code> is closed and <code>100</code> is fully open.</dd>
+        </dl>
+
+        <p>If <code>msg.topic</code> is <code>online</code> then <code>msg.payload</code> must be boolean and tells the online state of the window.</p>
+        <dl class="message-properties">
+            <dt>payload
+                <span class="property-type">boolean</span>
+            </dt>
+            <dd><code>true</code> sets online state to on, <code>false</code> sets online state to off.</dd>
+        </dl>
+
+        <p>If <code>msg.topic</code> is something other than the above topics then <code>msg.payload</code> must be an object and tells both the open state as well as the online state of the window.</p>
+        <dl class="message-properties">
+            <dt>payload.openPercent
+                <span class="property-type">integer</span>
+            </dt>
+            <dd>Value is the percentage that the window is opened where <code>0</code> is closed and <code>100</code> is fully open.</dd>
+            <dt>payload.online
+                <span class="property-type">boolean</span>
+            </dt>
+            <dd><code>true</code> sets online state to on, <code>false</code> sets online state to off.</dd>
+        </dl>
+
+        <p><b>Note 1:</b> <code>msg.topic</code> does not have to be exactly as shown above. You can use <code>/</code> as
+        a delimiter and as long as the last part of the topic matches one of the described topics all is good. 
+        For example, <code>a/msg/topic/openPercent</code> will be broken down into multiple parts and only the last part, 
+        <code>openPercent</code>, will be tested for a match.</p>
+        <p><b>Note 2:</b> If you set the online state to <code>false</code> then Google Smart Home is not going to be 
+        able to control the window.</p>
+
+        <h4>Output Messages</h4>
+        <p>Unless <code>Pass Through</code> is enabled, these messages are emitted when Google Smart Home wants to control the window.</p>
+        <dl class="message-properties">
+            <dt>payload.openPercent
+                <span class="property-type">integer</span>
+            </dt>
+            <dd>Value is the percentage that the window should be opened where <code>0</code> is closed and <code>100</code> is fully open.</dd>
+            <dt>payload.online
+                <span class="property-type">boolean</span>
+            </dt>
+            <dd><code>true</code> online state on, <code>false</code> online state off.</dd>
+        </dl>
+    
+    <h3>References</h3>
+        <p><a href="https://developers.google.com/actions/smarthome/guides/window" target="_new">Smart Home Window Guide</a>.</p>
+        <p><a href="https://www.npmjs.com/package/node-red-contrib-google-smarthome" target="_new">Node Information</a>.</p>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('google-window', {
+        category: 'Google_SmartHome-function',
+        paletteLabel: 'Window',
+        defaults: {
+            client: {
+                type: "googlesmarthome-client", 
+                required: true
+            },
+            name: {
+                value: "", required:true
+            },
+            topic: {
+                value: "", required:true
+            },
+            passthru: {
+                value: false
+            },
+        },
+        inputs: 1,
+        outputs: 1,
+        color:"#C0DEED",
+        icon: "google-smarthome.png",
+        label: function() {
+            return this.name || "Window";
+        },
+        labelStyle: function() {
+            return this.name ? "node_label_italic" : ""
+        }
+    })
+</script>

--- a/window.js
+++ b/window.js
@@ -1,0 +1,207 @@
+/**
+ * NodeRED Google SmartHome
+ * Copyright (C) 2018 Michael Jacobsen.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+module.exports = function(RED) {
+    "use strict";
+
+    const formats = require('./formatvalues.js');
+
+    /******************************************************************************************************************
+	 * 
+	 *
+	 */
+    function WindowNode(config) {
+        RED.nodes.createNode(this, config);
+
+        this.client     = config.client;
+        this.clientConn = RED.nodes.getNode(this.client);
+        this.topicOut   = config.topic;
+        this.passthru   = config.passthru;
+        this.topicDelim = '/';
+
+        if (!this.clientConn) {
+            this.error(RED._("window.errors.missing-config"));
+            this.status({fill:"red", shape:"dot", text:"Missing config"});
+            return;
+        } else if (typeof this.clientConn.register !== 'function') {
+            this.error(RED._("window.errors.missing-bridge"));
+            this.status({fill:"red", shape:"dot", text:"Missing SmartHome"});
+            return;            
+        }
+
+        let node = this;
+
+        RED.log.debug("WindowNode(): node.topicOut = " + node.topicOut);
+
+        /******************************************************************************************************************
+         * called when state is updated from Google Assistant
+         *
+         */
+        this.updated = function(states) {   // this must be defined before the call to clientConn.register()
+            RED.log.debug("WindowNode(updated): states = " + JSON.stringify(states));
+
+            if (states.openPercent == 0) {
+                node.status({fill:"green", shape:"dot", text:"CLOSED"});
+            } else {
+                node.status({fill:"red", shape:"dot", text:"OPEN"});
+            }
+
+            let msg = {
+                topic: node.topicOut,
+                payload: states
+            };
+
+            node.send(msg);
+        };
+
+        this.states = this.clientConn.register(this, 'window', config.name);
+
+        this.status({fill:"yellow", shape:"dot", text:"Ready"});
+
+        /******************************************************************************************************************
+         * respond to inputs from NodeRED
+         *
+         */
+        this.on('input', function (msg) {
+            RED.log.debug("WindowNode(input)");
+
+            let topicArr = msg.topic.split(node.topicDelim);
+            let topic    = topicArr[topicArr.length - 1];   // get last part of topic
+
+            RED.log.debug("WindowNode(input): topic = " + topic);
+
+            try {
+                if (topic.toUpperCase() === 'SET') {
+                    /*RED.log.debug("WindowNode(input): SET");
+                    let object = {};
+
+                    if (typeof msg.payload === 'object') {
+                        object = msg.payload;
+                    } else {
+                        RED.log.debug("WindowNode(input): typeof payload = " + typeof msg.payload);
+                        return;
+                    }
+
+                    let on     = node.states.on;
+                    let online = node.states.online;
+
+                    // on
+                    if (object.hasOwnProperty('on')) {
+                        on = formats.FormatValue(formats.Formats.BOOL, 'on', object.on);
+                    }
+
+                    // online
+                    if (object.hasOwnProperty('online')) {
+                        online = formats.FormatValue(formats.Formats.BOOL, 'online', object.online);
+                    }
+
+                    if (node.states.on !== on || node.states.online !== online){
+                        node.states.on     = on;
+                        node.states.online = online;
+
+                        node.clientConn.setState(node, node.states);  // tell Google ...
+
+                        if (node.passthru) {
+                            msg.payload = node.states;
+                            node.send(msg);
+                        }
+                    }*/
+                } else if (topic.toUpperCase() === 'OPENPERCENT') {
+                    RED.log.debug("WindowNode(input): OPEN/OPENPERCENT");
+                    let openPercent = formats.FormatValue(formats.Formats.INT, 'openPercent', msg.payload);
+
+                    if (node.states.openPercent !== openPercent) {
+                        node.states.openPercent = openPercent;
+
+                        node.clientConn.setState(node, node.states);  // tell Google ...
+
+                        if (node.passthru) {
+                            msg.payload = node.states.openPercent;
+                            node.send(msg);
+                        }
+                    }
+                } else if (topic.toUpperCase() === 'ONLINE') {
+                    RED.log.debug("WindowNode(input): ONLINE");
+                    let online = formats.FormatValue(formats.Formats.BOOL, 'online', msg.payload);
+
+                    if (node.states.online !== online) {
+                        node.states.online = online;
+
+                        node.clientConn.setState(node, node.states);  // tell Google ...
+
+                        if (node.passthru) {
+                            msg.payload = node.states.online;
+                            node.send(msg);
+                        }
+                    }
+                } else {
+                    RED.log.debug("WindowNode(input): some other topic");
+                    let object = {};
+
+                    if (typeof msg.payload === 'object') {
+                        object = msg.payload;
+                    } else {
+                        RED.log.debug("WindowNode(input): typeof payload = " + typeof msg.payload);
+                        return;
+                    }
+
+                    let openPercent     = node.states.openPercent;
+                    let online = node.states.online;
+
+                    // openPercent
+                    if (object.hasOwnProperty('openPercent')) {
+                        openPercent = formats.FormatValue(formats.Formats.INT, 'openPercent', object.openPercent);
+                    }
+
+                    // online
+                    if (object.hasOwnProperty('online')) {
+                        online = formats.FormatValue(formats.Formats.BOOL, 'online', object.online);
+                    }
+
+                    if (node.states.openPercent !== openPercent || node.states.online !== online){
+                        node.states.openPercent     = openPercent;
+                        node.states.online = online;
+
+                        node.clientConn.setState(node, node.states);  // tell Google ...
+
+                        if (node.passthru) {
+                            msg.payload = node.states;
+                            node.send(msg);
+                        }
+                    }
+                }
+            } catch (err) {
+                RED.log.error(err);
+            }
+        });
+
+        this.on('close', function(removed, done) {
+            if (removed) {
+                // this node has been deleted
+                node.clientConn.remove(node, 'window');
+            } else {
+                // this node is being restarted
+                node.clientConn.deregister(node, 'window');
+            }
+            
+            done();
+        });
+    }
+
+    RED.nodes.registerType("google-window", WindowNode);
+}


### PR DESCRIPTION
I added windows as supported devices. Windows can be opened or closed (fully or to a certain percentage value) and queried for their state.

Windows with multiple opening directions (blinds like [this one](https://developers.google.com/assistant/smarthome/images/smarthome-top-down-bottom-up-blinds.png)) not implemented yet.