### PR TITLE
Fix compatibility with Node.js 12

### DIFF
--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -75,7 +75,7 @@ module.exports = function(RED) {
                     states = node.app.NewLightDimmable(client, name);
                     break;
     
-		case 'light-temperature':
+		        case 'light-temperature':
                     states = node.app.NewLightColorTemp(client, name);
                     break;
 
@@ -103,7 +103,7 @@ module.exports = function(RED) {
                     states = node.app.NewWindow(client, name);
                     break;
 
-   		case 'vacuum':
+   		        case 'vacuum':
                     states = node.app.NewVacuum(client, name, param1);
                     break;
 

--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -153,7 +153,7 @@ module.exports = function(RED) {
          * notifications coming from the application server
          *
          */
-        this.app.on('server', function(state, param1) {
+        this.app.emitter.on('server', function(state, param1) {
             RED.log.debug("GoogleSmartHomeNode(on-server): state  = " + state);
             RED.log.debug("GoogleSmartHomeNode(on-server): param1 = " + param1);
 
@@ -164,7 +164,7 @@ module.exports = function(RED) {
             });
         });
 
-        this.app.on('actions-reportstate', function(msg) {
+        this.app.emitter.on('actions-reportstate', function(msg) {
             RED.log.debug("GoogleSmartHomeNode(on-actions-reportstate): msg = " + JSON.stringify(msg));
 
             node.callMgmtFuncs({
@@ -173,7 +173,7 @@ module.exports = function(RED) {
             });
         });
 
-        this.app.on('actions-requestsync', function(msg) {
+        this.app.emitter.on('actions-requestsync', function(msg) {
             RED.log.debug("GoogleSmartHomeNode(on-actions-requestsync): msg = " + JSON.stringify(msg));
 
             node.callMgmtFuncs({
@@ -182,7 +182,7 @@ module.exports = function(RED) {
             });
         });
 
-        this.app.on('/login', function(msg, username, password) {
+        this.app.emitter.on('/login', function(msg, username, password) {
             RED.log.debug("GoogleSmartHomeNode(on-login): msg      = " + msg);
             RED.log.debug("GoogleSmartHomeNode(on-login): username = " + username);
             RED.log.debug("GoogleSmartHomeNode(on-login): password = " + password);

--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -101,7 +101,7 @@ class Auth {
             }
         }, function(err) {
             process.nextTick(() => {
-                me.emit('auth', 'error', err);
+                me.emitter.emit('auth', 'error', err);
             });
         });
     }

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -612,7 +612,7 @@ class HttpActions {
             }).then((data) => {
                 let d = JSON.parse(data);
                 if (d.hasOwnProperty('error')) {
-                    me.debug('HttpActions:requestSync(): error; ' + d);
+                    me.debug('HttpActions:requestSync(): error; ' + JSON.stringify(d));
                     process.nextTick(() => {
                         me.emit('actions-requestsync', d);
                     });        

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -539,7 +539,7 @@ class HttpActions {
                     me.debug('HttpActions:reportState(): error; ' + JSON.stringify(d));
                     process.nextTick(() => {
                         d.deviceId = deviceId || "<none>";
-                        me.emit('actions-reportstate', d);
+                        me.emitter.emit('actions-reportstate', d);
                     });        
                 } else {
                     me.debug('HttpActions:reportState(): success');
@@ -614,7 +614,7 @@ class HttpActions {
                 if (d.hasOwnProperty('error')) {
                     me.debug('HttpActions:requestSync(): error; ' + JSON.stringify(d));
                     process.nextTick(() => {
-                        me.emit('actions-requestsync', d);
+                        me.emitter.emit('actions-requestsync', d);
                     });        
                 } else {
                     me.debug('HttpActions:requestSync(): success');

--- a/lib/HttpAuth.js
+++ b/lib/HttpAuth.js
@@ -159,7 +159,7 @@ class HttpAuth {
             let user = me.getUser(req.body.username, req.body.password);
             if (!user) {
                 process.nextTick(() => {
-                    me.emit('/login', 'invalid user', req.body.username, req.body.password);
+                    me.emitter.emit('/login', 'invalid user', req.body.username, req.body.password);
                 });
     
                 me.debug('HttpAuth:httpAuthRegister(/login): invalid user');
@@ -180,7 +180,7 @@ class HttpAuth {
           
             if (authCode) {
                 process.nextTick(() => {
-                    me.emit('/login', 'authCode successful', req.body.username, req.body.password);
+                    me.emitter.emit('/login', 'authCode successful', req.body.username, req.body.password);
                 });
 
                 me.debug('HttpAuth:httpAuthRegister(/login): authCode successful; authCode = ' + authCode);
@@ -188,7 +188,7 @@ class HttpAuth {
                     req.body.redirect_uri, authCode, req.body.state));
             } else {
                 process.nextTick(() => {
-                    me.emit('/login', 'authCode failed', req.body.username, req.body.password);
+                    me.emitter.emit('/login', 'authCode failed', req.body.username, req.body.password);
                 });
 
                 me.debug('HttpAuth:httpAuthRegister(/login): authCode failed');

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -31,8 +31,8 @@ const cors          = require('cors');
 const storage       = require('node-persist');
 const path          = require('path');
 const fs            = require('fs');
+const events        = require('events');
 
-const Emitter       = require('events').EventEmitter;
 const Aggregation   = require('./Aggregation.js');
 const Auth          = require('./Auth.js');
 const Devices       = require('./Devices.js');
@@ -43,7 +43,7 @@ const HttpActions   = require('./HttpActions.js');
  * GoogleSmartHome
  *
  */
-class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions, Emitter) {
+class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) {
     constructor(username, password, httpsPort, ssloffload, publicKey, privateKey, jwtkey, clientid, clientsecret, reportStateInterval, debug) {
         super();
 
@@ -59,6 +59,8 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions, 
 
         this.setClientIdSecret(clientid, clientsecret);
         this.setUsernamePassword(username, password);
+
+        this.emitter = new events.EventEmitter();
 
         // create express middleware
         this.app = express();
@@ -135,7 +137,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions, 
                 }
 
                 process.nextTick(() => {
-                    me.emit('server', 'start', me._httpsPort);
+                    me.emitter.emit('server', 'start', me._httpsPort);
                 });
             });
 
@@ -143,7 +145,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions, 
                 me.debug('SmartHome:Start(): err:' + err);
 
                 process.nextTick(() => {
-                    me.emit('server', 'error', err);
+                    me.emitter.emit('server', 'error', err);
                 });
             });
               
@@ -163,6 +165,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions, 
     //
     //
     Stop(done) {
+        let me = this;
         this._httpServerRunning = false;
 
         if (this._reportStateTimer !== null) {
@@ -172,15 +175,13 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions, 
 
         this.httpServer.stop(function() {
             process.nextTick(() => {
-                me.emit('server', 'stop', 0);
+                me.emitter.emit('server', 'stop', 0);
             });
 
             if (typeof done === 'function') {
                 done();
             }
         });
-
-        let me = this;
 
         setImmediate(function(){
             me.httpServer.emit('close');


### PR DESCRIPTION
Fixed compatibility with Node.js 12.

The problem was that `GoogleSmartHome` inherits from `EventEmitter`. Inheritance is done using Aggregation.js. This class uses `getOwnPropertyNames` and `getOwnPropertySymbols` to collect all properties of all classes it should inherit from. Until Node.js 10 `getOwnPropertySymbols` always returned an empty array. Since Node.js 12 `getOwnPropertySymbols` returns a symbol for the class `EventEmitter`. Aggregation.js then calls `match()` on that symbol. But since symbols don't have a String representation, there is nothing to call `match()` on.

The easiest way would be to remove the call to `getOwnPropertySymbols`. I tried that and it works. But I don't know what these symbols are used for and if it may have any negative effects to simply skip them.

Since I'm not a big fan of multiple inheritance anyway, I removed the inheritance from `EventEmitter` and replaced it with a class variable. I tested it with all my devices, unlinked and relinked my account and logged every event if they are still fired and received. So I am mostly sure everything still works.

Also fixed some wrong indentations and corrected another error message that said "error: [Object object]".