### PR TITLE
Add fan and vacuum to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   - [Thermostat](#--thermostat)
   - [Window](#--window)
   - [Scene](#--scene)
+  - [Vacuum](#--vacuum)
+  - [Fan](#--fan)
   - [Management](#--management)
 - [The config node](#the-config-node)
 - [Google SmartHome Setup Instructions](#google-smarthome-setup-instructions)
@@ -259,6 +261,50 @@ Example flow:
 
 #### - Scene
 Messages sent to this node is simply passed through. One cannot tell Google SmartHome to activate a scene, they tell us.
+
+
+#### - Vacuum
+`topic` can be `on`, `online` or something else.
+
+If `topic` is `on` then `payload` must be boolean and and tells the state of the vacuum.
+
+        msg.topic = 'on'
+        msg.payload = true
+
+If `topic` is `online` then `payload` must be boolean and tells the online state of the vacuum.
+
+        msg.topic = 'online'
+        msg.payload = true
+
+If `topic` is something else then `payload` must be an object and tells both the on state as well as the online state of the vacuum.
+
+        msg.topic = 'set'
+        msg.payload = {
+          on: true,
+          online: true
+        }
+
+
+#### - Fan
+`topic` can be `on`, `online` or something else.
+
+If `topic` is `on` then `payload` must be boolean and and tells the state of the fan.
+
+        msg.topic = 'on'
+        msg.payload = true
+
+If `topic` is `online` then `payload` must be boolean and tells the online state of the fan.
+
+        msg.topic = 'online'
+        msg.payload = true
+
+If `topic` is something else then `payload` must be an object and tells both the on state as well as the online state of the fan.
+
+        msg.topic = 'set'
+        msg.payload = {
+          on: true,
+          online: true
+        }
 
 #### - Management
 `topic` can be `restart_server`, `report_state` or `request_sync`.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ To install - change to your Node-RED user directory.
 
 *Note:* This version can output a lot of debug messages on the console. These messages are optional.
 
+*Note:* If you run Node-RED in Docker, set the folders `/data` and `/usr/src/node-red/.node-persist` as volumes.
+Both folders contain data that needs to be persisted.
+
 ---
 ## Nodes in this package
 ### General information

--- a/vacuum.html
+++ b/vacuum.html
@@ -83,7 +83,7 @@
             <dt>payload
                 <span class="property-type">boolean</span>
             </dt>
-            <dd><code>true</code> sets outlet to on, <code>false</code> sets outlet to off.</dd>
+            <dd><code>true</code> sets vacuum to on, <code>false</code> sets vacuum to off.</dd>
         </dl>
 
         <p>If <code>msg.topic</code> is <code>online</code> then <code>msg.payload</code> must be boolean and tells the online state of the vacuum.</p>


### PR DESCRIPTION
Fans and vacuums were missing from the Readme.

Also added a note about running in Docker to the readme. 