### PR TITLE
Use same node red port and url (with an optional path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ See the developer guide and release notes at [https://developers.google.com/acti
 
 #### Create and setup project in Actions Console
 
-1. Use the [Actions on Google Console](https://console.actions.google.com) to add a new project with a name of your choosing and click *Create Project*.
+1. Use the [Actions on Google Console](https://console.actions.google.com) to add a new project with a name of your choosing and click *Create Project*.  See [https://developers.google.com/assistant/smarthome/develop/create](Create a smart home Action) for more datails.
 2. Click *Home Control*, then click *Smart Home*.
 3. On the left navigation menu under *SETUP*, click on *Invocation*.
 4. Add your App's name. Click *Save*.
@@ -415,7 +415,7 @@ See the developer guide and release notes at [https://developers.google.com/acti
 #### Add Request Sync
 ~~*Note: I'm almost certain this part is not needed.*~~
 
-The Request Sync feature allows the nodes in this package to send a request to the Home Graph to send a new SYNC request.
+The Request Sync feature allows the nodes in this package to send a request to the Home Graph to send a new SYNC request. See [https://developers.google.com/assistant/smarthome/develop/request-sync](Request Sync) for more datails.
 
 1. Navigate to the [Google Cloud Console API Manager](https://console.developers.google.com/apis) for your project id.
 2. Enable the [HomeGraph API](https://console.cloud.google.com/apis/api/homegraph.googleapis.com/overview). This will be used to request a new sync and to report the state back to the HomeGraph.
@@ -426,7 +426,7 @@ The Request Sync feature allows the nodes in this package to send a request to t
 7. ~~Enable Request-Sync API using [these instructions](https://developers.google.com/actions/smarthome/create-app#request-sync).~~
 
 #### Add Report State
-The Report State feature allows the nodes in this package to proactively provide the current state of devices to the Home Graph without a `QUERY` request. This is done securely through [JWT (JSON web tokens)](https://jwt.io/).
+The Report State feature allows the nodes in this package to proactively provide the current state of devices to the Home Graph without a `QUERY` request. This is done securely through [JWT (JSON web tokens)](https://jwt.io/). See [https://developers.google.com/assistant/smarthome/develop/report-state](Report State) for more datails.
 
 1. Navigate to the [Google Cloud Console API & Services page](https://console.cloud.google.com/apis/credentials)
 2. Select **Create Credentials** and create a **Service account key**

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ If `topic` is something else then `payload` must be an object and tells both the
 
   `Use http Node-RED root path`: If enabled, use the same http root path prefix configured for Node-RED, otherwise use /.
 
-  `Path`: The path prefix to use for the requests. Default is /smarthome
+  `Path`: The path prefix to use for the requests. Default is /smarthome.
 
   `Port`: TCP port of your choosing for incoming connections from Google. Must match what you entered in the *Google on Actions* project.
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ If `topic` is something else then `payload` must be an object and tells both the
 
   `Use http Node-RED root path`: If enabled, use the same http root path prefix configured for Node-RED, otherwise use /.
 
+  `Path`: The path prefix to use for the requests. Default is /smarthome
+
   `Port`: TCP port of your choosing for incoming connections from Google. Must match what you entered in the *Google on Actions* project.
 
   `Use external SSL offload`: If enabled, SSL encryption is not used by the node and must be done elsewhere.
@@ -549,21 +551,37 @@ fi
 echo
 ```
 
+**command_on**
+```
+#!/usr/bin/env bash
+. ./data
+. ./code
+
+SH_REQUEST="{\"inputs\":[{\"context\":{\"locale_country\":\"US\",\"locale_language\":\"en\"},\"intent\":\"action.devices.EXECUTE\",\"payload\":{\"commands\":[{\"devices\":[{\"customData\":{\"nodeid\":\"$NODE_ID\",\"type\":\"light-dimmable\"},\"id\":\"$NODE_ID\"}],\"execution\":[{\"command\":\"action.devices.commands.OnOff\",\"params\":{\"on\":true}}]}]}}],\"requestId\":\"123456789\"}"
+
+curl -s \
+        -H "authorization: Bearer $ACCESS_TOKEN" \
+        -H "Content-Type: application/json;charset=UTF-8" \
+        --data "$SH_REQUEST" \
+        $BASE_URL/smarthome
+echo ""
+```
+
 **data**
 ```
 #!/usr/bin/env bash
-PROJECT_ID=PROJECT_ID_FILL_IT
+PROJECT_ID="PROJECT_ID_FILL_IT"
 GOOGLE_CLIENT_ID=123456789012345678901
-STATE_STRING=STATE_STRING_FILL_IT
-REQUESTED_SCOPES=REQUESTED_SCOPES_FILL_IT
-LOCALE=LOCALE_FILL_IT
-REDIRECT_URI=https://oauth-redirect.googleusercontent.com/r/$PROJECT_ID
+STATE_STRING="STATE_STRING_FILL_IT"
+REQUESTED_SCOPES="REQUESTED_SCOPES_FILL_IT"
+LOCALE="LOCALE_FILL_IT"
+REDIRECT_URI="https://oauth-redirect.googleusercontent.com/r/$PROJECT_ID"
 REDIRECT_URI=$(printf "%q" "$REDIRECT_URI")
-REDIREDT_URI=TEST
-BASE_URL=http://localhost:3001
-USERNAME=my_user
-PWD=my_password
+BASE_URL="http://localhost:1880/smart-home"
+USERNAME="my_user"
+PWD="my_password"
 CLIENT_SECRET="some-secret-shared-with-google"
+NODE_ID="1c188980.6d0c87"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ See the developer guide and release notes at [https://developers.google.com/acti
 
 #### Create and setup project in Actions Console
 
-1. Use the [Actions on Google Console](https://console.actions.google.com) to add a new project with a name of your choosing and click *Create Project*.  See [https://developers.google.com/assistant/smarthome/develop/create](Create a smart home Action) for more datails.
+1. Use the [Actions on Google Console](https://console.actions.google.com) to add a new project with a name of your choosing and click *Create Project*.  See [Create a smart home Action](https://developers.google.com/assistant/smarthome/develop/create) for more datails.
 2. Click *Home Control*, then click *Smart Home*.
 3. On the left navigation menu under *SETUP*, click on *Invocation*.
 4. Add your App's name. Click *Save*.
@@ -415,7 +415,7 @@ See the developer guide and release notes at [https://developers.google.com/acti
 #### Add Request Sync
 ~~*Note: I'm almost certain this part is not needed.*~~
 
-The Request Sync feature allows the nodes in this package to send a request to the Home Graph to send a new SYNC request. See [https://developers.google.com/assistant/smarthome/develop/request-sync](Request Sync) for more datails.
+The Request Sync feature allows the nodes in this package to send a request to the Home Graph to send a new SYNC request. See [Request Sync](https://developers.google.com/assistant/smarthome/develop/request-sync) for more datails.
 
 1. Navigate to the [Google Cloud Console API Manager](https://console.developers.google.com/apis) for your project id.
 2. Enable the [HomeGraph API](https://console.cloud.google.com/apis/api/homegraph.googleapis.com/overview). This will be used to request a new sync and to report the state back to the HomeGraph.
@@ -426,7 +426,7 @@ The Request Sync feature allows the nodes in this package to send a request to t
 7. ~~Enable Request-Sync API using [these instructions](https://developers.google.com/actions/smarthome/create-app#request-sync).~~
 
 #### Add Report State
-The Report State feature allows the nodes in this package to proactively provide the current state of devices to the Home Graph without a `QUERY` request. This is done securely through [JWT (JSON web tokens)](https://jwt.io/). See [https://developers.google.com/assistant/smarthome/develop/report-state](Report State) for more datails.
+The Report State feature allows the nodes in this package to proactively provide the current state of devices to the Home Graph without a `QUERY` request. This is done securely through [JWT (JSON web tokens)](https://jwt.io/). See [Report State](https://developers.google.com/assistant/smarthome/develop/report-state) for more datails.
 
 1. Navigate to the [Google Cloud Console API & Services page](https://console.cloud.google.com/apis/credentials)
 2. Select **Create Credentials** and create a **Service account key**

--- a/google-smarthome.html
+++ b/google-smarthome.html
@@ -84,8 +84,13 @@
     </div>
 
     <div class="form-row">
+        <label for="node-config-input-httppath"><i class="fa fa-folder"></i> <span data-i18n="googlesmarthome.label.httppath"></span></label>
+        <input type="text" id="node-config-input-httppath">
+    </div>
+
+    <div class="form-row">
         <label for="node-config-input-port"><i class="fa fa-globe"></i> <span data-i18n="googlesmarthome.label.port"></span></label>
-        <input type="text" id="node-config-input-port" 3001>
+        <input type="text" id="node-config-input-port" data-i18n="[placeholder]googlesmarthome.placeholder.port">
     </div>
 
     <div class="form-row">
@@ -143,7 +148,10 @@
                 value: true
             },
             port: {
-                value:3001, required:true, validate:RED.validators.number(true)
+                value:0, required:false, validate:RED.validators.number(true)
+            },
+            httppath: {
+                value:"smarthome", required: false
             },
             ssloffload: {
                 value: false

--- a/google-smarthome.html
+++ b/google-smarthome.html
@@ -123,6 +123,8 @@
     <code>Report Interval (m)</code>: Time, in minutes, between report updates are sent to Google.<br>
     <br>
     <b>Built-in Web Server Settings</b><br>
+    <code>Use http Node-RED root path</code>: If enabled, use the same http root path prefix configured for Node-RED, otherwise use /.<br>
+    <code>Path</code>: The path prefix to use for the requests. Default is /smarthome.<br>
     <code>Port</code>: TCP port of your choosing for incoming connections from Google. Must match what you entered in the <b>Google on Actions</b> project.<br>
     <code>External SSL offload</code>: If enabled, SSL encryption is not used by the node and must be done elsewhere.
     <code>Public Key</code>: Full path to public key file, e.g. `fullchain.pem` from Let's Encrypt.<br>

--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -48,7 +48,8 @@ module.exports = function(RED) {
             config.password,
             parseInt(config.accesstokenduration), // minutes
             config.usehttpnoderoot,
-            parseInt(config.port),
+            config.httppath,
+            parseInt(config.port || '0'),
             config.ssloffload,
             config.publickey, 
             config.privatekey,
@@ -58,7 +59,7 @@ module.exports = function(RED) {
             config.reportinterval,     // minutes
             config.enabledebug);
 
-        let err = this.app.Start();
+        let err = this.app.Start(RED.httpNode || RED.httpAdmin);
         if (err !== true) {
             RED.log.error(err);
             return;

--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -36,6 +36,7 @@ class Auth {
         this._authCode     = null;
         this._auth         = null;
         this._authFilename = null;
+        this._jwtkey       = null;
         this._accessTokenDuration = 60;
         this._tokenGen     = new TokenGenerator(256, TokenGenerator.BASE58);
     }

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -36,8 +36,11 @@ class HttpActions {
     //
     //
     //
-    httpActionsRegister(httpRoot) {
+    httpActionsRegister(httpRoot, appHttp) {
         let me = this;
+        if (typeof appHttp === 'undefined') {
+            appHttp = this.app;
+        }
 
         /**
          *
@@ -55,7 +58,7 @@ class HttpActions {
          *   }
          * }
          */
-        this.app.post(path.join(httpRoot, 'smarthome'), function(request, response) {
+        appHttp.post(path.join(httpRoot, 'smarthome'), function(request, response) {
             let reqdata = request.body;
 
             me.debug('HttpActions:httpActionsRegister(/smarthome): request.headers = ' + JSON.stringify(request.headers));
@@ -225,7 +228,7 @@ class HttpActions {
         /**
          * Enables prelight (OPTIONS) requests made cross-domain.
          */
-        this.app.options('/smarthome', function(request, response) {
+        appHttp.options(path.join(httpRoot, 'smarthome'), function(request, response) {
             response.status(200).set({
                 'Access-Control-Allow-Headers': 'Content-Type, Authorization',
             }).send('null');
@@ -399,7 +402,7 @@ class HttpActions {
         this.debug('HttpActions:_execDevice(): execDevice = ' + JSON.stringify(execDevice));
 
         // check whether the device exists or whether it exists and it is disconnected.
-        if (!execDevice || !execDevice[device.id].states.online) {
+        if (!execDevice || !execDevice[device.id] || !execDevice[device.id].states.online) {
             this.debug('HttpActions:_execDevice(): the device you want to control is offline');
             return {status: 'ERROR', errorCode: 'deviceOffline'};
         }

--- a/lib/HttpAuth.js
+++ b/lib/HttpAuth.js
@@ -32,8 +32,11 @@ class HttpAuth {
     //
     //
     //
-    httpAuthRegister(httpRoot) {
+    httpAuthRegister(httpRoot, appHttp) {
         let me = this;
+        if (typeof appHttp === 'undefined') {
+            appHttp = this.app;
+        }
 
         /**
          * expecting something like the following:
@@ -49,7 +52,7 @@ class HttpAuth {
          *   &response_type=code
          *      - The string code
          */
-        this.app.get(path.join(httpRoot, 'oauth'), function(req, res) {
+        appHttp.get(path.join(httpRoot, 'oauth'), function(req, res) {
             me.debug('HttpAuth:httpAuthRegister(GET /oauth)');
 
             if (req.query.response_type !== 'code') {
@@ -72,7 +75,7 @@ class HttpAuth {
         //
         //
         //
-        this.app.post(path.join(httpRoot, 'oauth'), function(req, res) {
+        appHttp.post(path.join(httpRoot, 'oauth'), function(req, res) {
             me.debug('HttpAuth:httpAuthRegister(POST /oauth): body = ' + JSON.stringify(req.body));
 
             let response_type = req.query.response_type ? req.query.response_type : req.body.response_type;
@@ -144,7 +147,7 @@ class HttpAuth {
          * &grant_type=refresh_token
          * &refresh_token=REFRESH_TOKEN
          */
-        this.app.all(path.join(httpRoot, 'token'), function(req, res) {
+        appHttp.all(path.join(httpRoot, 'token'), function(req, res) {
             me.debug('HttpAuth:httpAuthRegister(/token): query = ' + JSON.stringify(req.query));
             me.debug('HttpAuth:httpAuthRegister(/token): body = ' + JSON.stringify(req.body));
 

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -49,7 +49,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
         this._reportStateTimer      = null;
         this._reportStateInterval   = reportStateInterval;  // minutes
         this._httpNodeRoot          = httpNodeRoot;
-        this._httpPath              = path.join('/', httpPath);
+        this._httpPath              = path.join('/', httpPath || '');
         this._httpsPort             = httpsPort;
         this._sslOffload            = ssloffload;
         this._publicKey             = publicKey;

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -28,6 +28,7 @@ const morgan        = require('morgan');
 const cors          = require('cors');
 const fs            = require('fs');
 const events        = require('events');
+const path          = require('path');
 
 const Aggregation   = require('./Aggregation.js');
 const Auth          = require('./Auth.js');
@@ -40,11 +41,15 @@ const HttpActions   = require('./HttpActions.js');
  *
  */
 class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) {
-    constructor(nodeId, userDir, httpNodeRoot, username, password, accessTokenDuration, usehttpnoderoot, httpsPort, ssloffload, publicKey, privateKey, jwtkey, clientid, clientsecret, reportStateInterval, debug) {
+    constructor(nodeId, userDir, httpNodeRoot, username, password, accessTokenDuration, usehttpnoderoot, 
+        httpPath, httpsPort, ssloffload, publicKey, privateKey, jwtkey, clientid, 
+        clientsecret, reportStateInterval, debug) {
         super();
 
         this._reportStateTimer      = null;
         this._reportStateInterval   = reportStateInterval;  // minutes
+        this._httpNodeRoot          = httpNodeRoot;
+        this._httpPath              = path.join('/', httpPath);
         this._httpsPort             = httpsPort;
         this._sslOffload            = ssloffload;
         this._publicKey             = publicKey;
@@ -61,59 +66,36 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
 
         this.emitter = new events.EventEmitter();
 
-        // create express middleware
-        this.app = express();
-        this.app.use(helmet());
-        this.app.use(cors());
-        this.app.use(morgan('dev'));
-        this.app.use(bodyParser.json());
-        this.app.use(bodyParser.urlencoded({extended: true}));
-        this.app.set('trust proxy', 1); // trust first proxy
+        if (httpsPort > 0) {
+            // create express middleware
+            this.app = express();
+            this.app.use(helmet());
+            this.app.use(cors());
+            this.app.use(morgan('dev'));
+            this.app.use(bodyParser.json());
+            this.app.use(bodyParser.urlencoded({extended: true}));
+            this.app.set('trust proxy', 1); // trust first proxy
 
-        // frontend UI
-        this.app.set('jsonp callback name', 'cid');
+            // frontend UI
+            this.app.set('jsonp callback name', 'cid');
 
-        this.httpAuthRegister(usehttpnoderoot ? httpNodeRoot : '/');        // login and oauth http interface
-        this.httpActionsRegister(usehttpnoderoot ? httpNodeRoot : '/');     // actual SmartHome http interface
+            this.httpAuthRegister(path.join(usehttpnoderoot ? this._httpNodeRoot : '/', this._httpPath));        // login and oauth http interface
+            this.httpActionsRegister(path.join(usehttpnoderoot ? this._httpNodeRoot : '/', this._httpPath));     // actual SmartHome http interface
+        }
     }
     //
     //
     //
-    Start() {
+    Start(REDapp) {
         try {
             const graceMilliseconds = 500;
             let me                  = this;
 
-            this.setJwtKey(this._jwtKey, this._userDir);     // will throw if file cannot be read
-            
-            if (this._sslOffload) {
-                me.debug('SmartHome:Start(listen): using external SSL offload');
-
-                // create our HTTP server
-                this.httpServer = stoppable(http.createServer(this.app), graceMilliseconds);
-            } else {
-                me.debug('SmartHome:Start(listen): using internal SSL');
-
-                // set SSL certificate
-                const httpsOptions = {
-                    key  : fs.readFileSync(this._privateKey),
-                    cert : fs.readFileSync(this._publicKey)
-                };
-
-                // create our HTTPS server
-                this.httpServer = stoppable(https.createServer(httpsOptions, this.app), graceMilliseconds);
-            }
-
-            // start server
-            this.httpServer.listen(this._httpsPort, () => {
-                me._httpServerRunning = true;
-
-                const host = me.httpServer.address().address;
-                const port = me.httpServer.address().port;
-
-                me.debug('SmartHome:Start(listen): listening at ' + host + ':' + port);
+            if (this._jwtKey) {
+                this.setJwtKey(this._jwtKey, this._userDir);     // will throw if file cannot be read
 
                 if (this._reportStateInterval > 0) {
+                
                     this._reportStateTimer = setInterval(function() { 
                         let states = me.getStates();
 
@@ -122,26 +104,60 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
                         }
                     }, this._reportStateInterval * 60 * 1000);
                 }
+            }
 
-                process.nextTick(() => {
-                    me.emitter.emit('server', 'start', me._httpsPort);
-                });
-            });
+            if (this._httpsPort > 0) {
+                if (this._sslOffload) {
+                    me.debug('SmartHome:Start(listen): using external SSL offload');
 
-            this.httpServer.on('error', function (err) {
-                me.debug('SmartHome:Start(): err:' + err);
+                    // create our HTTP server
+                    this.httpServer = stoppable(http.createServer(this.app), graceMilliseconds);
+                } else {
+                    me.debug('SmartHome:Start(listen): using internal SSL');
 
-                process.nextTick(() => {
-                    me.emitter.emit('server', 'error', err);
-                });
-            });
+                    // set SSL certificate
+                    const httpsOptions = {
+                        key  : fs.readFileSync(this._privateKey),
+                        cert : fs.readFileSync(this._publicKey)
+                    };
 
-            me.debug('SmartHome:Start(): registered routes:');
-            this.app._router.stack.forEach((r) => {
-                if (r.route && r.route.path) {
-                    me.debug('SmartHome:Start(): ' + r.route.path);
+                    // create our HTTPS server
+                    this.httpServer = stoppable(https.createServer(httpsOptions, this.app), graceMilliseconds);
                 }
-            });
+
+                // start server
+                this.httpServer.listen(this._httpsPort, () => {
+                    me._httpServerRunning = true;
+
+                    const host = me.httpServer.address().address;
+                    const port = me.httpServer.address().port;
+
+                    me.debug('SmartHome:Start(listen): listening at ' + host + ':' + port);
+
+                    process.nextTick(() => {
+                        me.emitter.emit('server', 'start', me._httpsPort);
+                    });
+                });
+
+                this.httpServer.on('error', function (err) {
+                    me.debug('SmartHome:Start(): err:' + err);
+
+                    process.nextTick(() => {
+                        me.emitter.emit('server', 'error', err);
+                    });
+                });
+
+                me.debug('SmartHome:Start(): registered routes:');
+                this.app._router.stack.forEach((r) => {
+                    if (r.route && r.route.path) {
+                        me.debug('SmartHome:Start(): ' + r.route.path);
+                    }
+                });
+            } else {
+                me.debug("GoogleSmartHomeNode(): use the Node-RED server port, path " + path.join(this._httpNodeRoot, this._httpPath));
+                this.httpAuthRegister(this._httpPath, REDapp);        // login and oauth http interface
+                this.httpActionsRegister(this._httpPath, REDapp);     // actual SmartHome http interface
+            }
         } catch (err) {
             return err;
         }
@@ -153,14 +169,28 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     Stop(done) {
         let me = this;
-        this._httpServerRunning = false;
-
         if (this._reportStateTimer !== null) {
             clearTimeout(this._reportStateTimer);
             this._reportStateTimer  = null;
         }
 
-        this.httpServer.stop(function() {
+        if (this._httpServerRunning) {
+            this._httpServerRunning = false;
+
+            this.httpServer.stop(function() {
+                process.nextTick(() => {
+                    me.emitter.emit('server', 'stop', 0);
+                });
+
+                if (typeof done === 'function') {
+                    done();
+                }
+            });
+
+            setImmediate(function(){
+                me.httpServer.emit('close');
+            });
+        } else {
             process.nextTick(() => {
                 me.emitter.emit('server', 'stop', 0);
             });
@@ -168,11 +198,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
             if (typeof done === 'function') {
                 done();
             }
-        });
-
-        setImmediate(function(){
-            me.httpServer.emit('close');
-        });
+        }
     }
     //
     //
@@ -209,7 +235,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     //
     IsHttpServerRunning() {
-        return this._httpServerRunning;
+        return this._httpServerRunning || this._httpsPort <= 0;
     }
     //
     //

--- a/lib/frontend/login.html
+++ b/lib/frontend/login.html
@@ -169,7 +169,7 @@
     <h1>Link your devices to Google</h1>
     <svg xmlns="http://www.w3.org/2000/svg" baseProfile="tiny" width="100px" height="100px" id="Layer_1" viewBox="0 0 512 512" xml:space="preserve"><g><circle cx="156.268" cy="167.705" fill="#4285F4" r="156.268"/><path d="M512,182.95c0,17.544-14.224,31.762-31.762,31.762s-31.762-14.218-31.762-31.762   c0-17.543,14.224-31.762,31.762-31.762S512,165.407,512,182.95z" fill="#34A853"/><path d="M454.829,260.449c0,35.081-28.438,63.522-63.523,63.522c-35.088,0-63.524-28.441-63.524-63.522   c0-35.083,28.437-63.524,63.524-63.524C426.392,196.925,454.829,225.367,454.829,260.449z" fill="#EA4335"/><path d="M467.533,424.339c0,42.1-34.124,76.225-76.228,76.225c-42.104,0-76.229-34.125-76.229-76.225   c0-42.098,34.124-76.227,76.229-76.227C433.409,348.112,467.533,382.241,467.533,424.339z" fill="#FBBC05"/></g></svg>
 
-    <form action="/oauth" method="post" id="loginform">
+    <form method="post" id="loginform">
 
         <div id="error_invalid_user">
             Invalid username or password. Please try again!
@@ -211,6 +211,8 @@
     }
 
     document.addEventListener("DOMContentLoaded", function(event) {
+        let url = window.location.href.split('?')[0];
+        document.getElementById("loginform").action = url;
         // Get URL parameters
         let params = getUrlParameters();
 

--- a/locales/en-US/google-smarthome.json
+++ b/locales/en-US/google-smarthome.json
@@ -6,6 +6,7 @@
             "password": "Password",
             "accesstokenduration": "Access Token Duration (m)",
             "usehttpnoderoot": "Use http Node-RED root path",
+            "httppath": "Path",
             "port": "Port",
             "clientid": "Client ID",
             "clientsecret": "Client Secret",
@@ -24,6 +25,7 @@
             "privatekey": "Filename",
             "jwtkey": "Filename",
             "accesstokenduration": "Interval in minutes",
+            "port": "Server port. -1 or empty for the Node-RED port",
             "reportinterval": "Interval in minutes. -1 to disable"
         },
         "state": {

--- a/locales/it_IT/google-smarthome.json
+++ b/locales/it_IT/google-smarthome.json
@@ -6,6 +6,7 @@
             "password": "Password",
             "accesstokenduration": "Durata del token di accesso (m)",
             "usehttpnoderoot": "Usa il percorso radice http di Node-RED",
+            "httppath": "Percorso",
             "port": "Porta",
             "clientid": "ID del client",
             "clientsecret": "Segreto del client",
@@ -24,6 +25,7 @@
             "privatekey": "Nome file",
             "jwtkey": "Nome file",
             "accesstokenduration": "Intervallo in minuti",
+            "port": "Porta del server. -1 o vuoto per quella di Node-RED",
             "reportinterval": "Intervallo in minuti. -1 per disabilitare"
         },
         "state": {


### PR DESCRIPTION
Hi,
this pull request allows us to use the same port used by Node-RED. Is uses the same expressjs HTTP server, and avoid the need to start a new HTTP server.
I've added a path prefix, in order to don't conflict with other paths already used, the default path prefix is "smarthome".
I hope you want to merge it.

Thanks
Claudio
