### PR TITLE
moving "command" outside of payload.

### DIFF
--- a/devices/shutter.js
+++ b/devices/shutter.js
@@ -102,6 +102,7 @@ module.exports = function(RED) {
          */
         this.updated = function(device) {   // this must be defined before the call to clientConn.register()
             let states = device.states;
+            let command = device.command;
             RED.log.debug("ShutterNode(updated): states = " + JSON.stringify(states));
 
             node.updateStatusIcon(states);
@@ -109,7 +110,11 @@ module.exports = function(RED) {
             let msg = {
                 topic: node.topicOut,
                 device_name: device.properties.name.name,
-                payload: states
+                command: command,
+                payload: {
+                    online: states.online,
+                    openPercent: states.openPercent
+                }
             };
 
             node.send(msg);

--- a/lib/Devices.js
+++ b/lib/Devices.js
@@ -136,6 +136,12 @@ class Devices {
             });
         }
 
+        if (device.hasOwnProperty('command')) {
+            // update command
+                    me.debug('Device:execDevice(): command = ' + device.command);
+                    me._devices[device.id].command = device.command;
+        }
+        
         if (device.hasOwnProperty('executionStates')) {
             // update array of states
             me.debug('Device:execDevice(): executionStates = ' + JSON.stringify(device.executionStates));

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -382,8 +382,8 @@ class HttpActions {
         };
         
         if (command.hasOwnProperty('command')) {
-			curDevice.states['command'] = command.command;
-		}
+            curDevice.command = command.command;
+        }
         
         if (command.hasOwnProperty('params')) {
             Object.keys(command.params).forEach(function (key) {
@@ -432,12 +432,6 @@ class HttpActions {
         execDevice = execDevice[curDevice.id];
 
         payLoadDevice.states = execDevice.states;
-
-        // TODO: This now causes '"code":400,"message":"Request contains an invalid argument."' errors. Parts of the command, e.g. 'onoff' end up in the devices status
-        //       data, which in turn makes google complain when doing a reportState.
-        //
-        // since some commands won't deliver any parameters (like dock or locate), the payload should include the command name.
-        //payLoadDevice.states.command = command.command.split(/[. ]+/).pop().toLowerCase();
 
         if (command.hasOwnProperty('params')) {
             Object.keys(command.params).forEach(function (key) {


### PR DESCRIPTION
moving "command" outside of payload to prevent other / wrong states leaking into reportState()

example: shutter.js

In my opinion, the information about the used 'command' is better kept outside the payload.

As a next step, we could check whether the payload / the states only contain informations that are specified in the registerDevice function.

This solves the following "HttpActions.js; Line 436":
```
        // TODO: This now causes '"code":400,"message":"Request contains an invalid argument."' errors. Parts of the command, e.g. 'onoff' end up in the devices status
        //       data, which in turn makes google complain when doing a reportState.
        //
        // since some commands won't deliver any parameters (like dock or locate), the payload should include the command name.
        //payLoadDevice.states.command = command.command.split(/[. ]+/).pop().toLowerCase();
```


**In the process of the merge, all other devices would have to be adapted.**