### PR TITLE
Fix _execDevice for Media Devices and other nodes

### DIFF
--- a/devices/media.js
+++ b/devices/media.js
@@ -692,7 +692,7 @@ module.exports = function(RED) {
                 } else {
                     RED.log.debug('MediaNode:loadJson(): data loaded');
                     const json = JSON.parse(jsonFile);
-                    RED.log.debug('MediaNode:loadAuth(): json = ' + JSON.stringify(json));
+                    RED.log.debug('MediaNode:loadJson(): json = ' + JSON.stringify(json));
                     return json;
                 }
             }

--- a/devices/media.js
+++ b/devices/media.js
@@ -265,7 +265,7 @@ module.exports = function(RED) {
             this.updateAttributesForTraits(me, device);
             this.updateStatesForTraits(me, device);
 
-            RED.log.debug("MediaNode(updated): device = " + JSON.stringify(device));
+            RED.log.debug("MediaNode(registerDevice): device = " + JSON.stringify(device));
 
             return device;
         }

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -408,7 +408,7 @@ class HttpActions {
                     delete command.params.color.spectrumRGB;
                 }*/
 
-                if (command.params.hasOwnProperty(key)) {
+                if (curDevice.states.hasOwnProperty(key)) {
                     curDevice.states[key] = command.params[key];
                 }
             });

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -397,6 +397,7 @@ class HttpActions {
         }
         
         if (command.hasOwnProperty('params')) {
+            let cur_device=this._devices[device.id] || { "states":{} };
             Object.keys(command.params).forEach(function (key) {
                 // arrgggghhhh - why Google, why ...
                 if (key === 'color' && command.params.color.hasOwnProperty('spectrumHSV')) {
@@ -408,7 +409,7 @@ class HttpActions {
                     delete command.params.color.spectrumRGB;
                 }*/
 
-                if (curDevice.states.hasOwnProperty(key)) {
+                if (cur_device.states.hasOwnProperty(key)) {
                     curDevice.states[key] = command.params[key];
                 }
             });


### PR DESCRIPTION
Hi,
I think I've detected a mistake in the _execDevice, please review carefully before merging it.
The problem I've found is in the following rows:

        if (command.hasOwnProperty('params')) {
            let cur_device=this._devices[device.id] || { "states":{} };
            Object.keys(command.params).forEach(function (key) {
                // arrgggghhhh - why Google, why ...
                if (key === 'color' && command.params.color.hasOwnProperty('spectrumHSV')) {
                    command.params.color.spectrumHsv = command.params.color.spectrumHSV;
                    delete command.params.color.spectrumHSV;
                }

                // if (command.params.hasOwnProperty(key)) {         //  Original Line
                if (cur_device.states.hasOwnProperty(key)) {               // New Line
                    curDevice.states[key] = command.params[key];
                }
            });
        }

Because the forEach is for command.params, it always has the key property, I think is correct to check if the current device has this key property before assigning it.
What do You think about it?
Could this fix break the other nodes?

Thanks
Claudio

