### PR TITLE
Fixed typo. undedined must be undefined

### DIFF
--- a/devices/device.js
+++ b/devices/device.js
@@ -1238,7 +1238,7 @@
                         text += ' ' + this.states.humidityAmbientPercent + "% ";
                     }
                     if (this.trait.openclose) {
-                        if (this.states.openPercent !== undedined) {
+                        if (this.states.openPercent !== undefined) {
                             text += ' ' + this.states.humidityAmbientPercent + "% ";
                         }
                     }


### PR DESCRIPTION
There is a small typo for the openPercent state.