### PR TITLE
Camera update token and send message

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ and the following Google [traits](https://developers.google.com/assistant/smarth
 * Volume
 
 Example flow:
-        See the flow used for the automatic tests [here](test/sh/flow.json)
+        See the flow used for the automatic tests [here](test/sh/flows.json)
 
 #### - Light On/Off (a light that can be switched on and off only)
 `topic` can be `on`, `online` or something else.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ and the following Google [traits](https://developers.google.com/assistant/smarth
 * Transport control
 * Volume
 
+Example flow:
+        See the flow used for the automatic tests [here](test/sh/flow.json)
+
 #### - Light On/Off (a light that can be switched on and off only)
 `topic` can be `on`, `online` or something else.
 

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -382,12 +382,16 @@ class HttpActions {
         };
         
         let result = {};
+        let reportState = true;
         if (command.hasOwnProperty('command')) {
             curDevice.command = command.command;
             result = this.execCommand(curDevice, command); // Devices.execCommand
             if (result) {
                 if (result.hasOwnProperty('status')) {
                     return result;
+                }
+                if (result.hasOwnProperty('reportState')) {
+                    reportState = result.reportState;
                 }
                 if (result.hasOwnProperty("params") && Object.keys(result.params).length > 0) {
                     command.params = result.params;
@@ -457,20 +461,27 @@ class HttpActions {
         let me = this;
         let id = device.id;
 
-        // update states in HomeGraph
-        process.nextTick(() => {
-            let s = me.getStates([id]);
-            me.reportState(id, s[id]);
-        });
+        if (reportState) {
+            // update states in HomeGraph
+            process.nextTick(() => {
+                let s = me.getStates([id]);
+                me.reportState(id, s[id]);
+            });
+        }
 
         let executionStates = execDevice.executionStates;
         if (result.hasOwnProperty('executionStates') && Object.keys(result.executionStates).length > 0) {
             executionStates = result['executionStates'];
         }
 
+        let states = execDevice.states;
+        if (result.hasOwnProperty("states") && Object.keys(result.states).length > 0) {
+            states = result.states;
+        }
+
         return {
             status: 'SUCCESS',
-            states: execDevice.states,
+            states: states,
             executionStates: executionStates,
         };
     }

--- a/test/sh/device_test.sh
+++ b/test/sh/device_test.sh
@@ -215,35 +215,35 @@ test_payload ".brightness" 208
 # CameraStream
 echo
 echo CameraStream
-execute_no_payload $NODE_ID GetCameraStream true '"progressive_mp4"'
+execute $NODE_ID GetCameraStream true '"progressive_mp4"'
 test_out ".payload.commands[0].states.online" true
 test_out ".payload.commands[0].states.cameraStreamAccessUrl" '"http://PROGRESSIVE_MP4"'
 test_out ".payload.commands[0].states.cameraStreamProtocol" '"progressive_mp4"'
 test_out ".payload.commands[0].states.cameraStreamAuthToken" '"Auth Token"'
 test_out ".payload.commands[0].states.cameraStreamReceiverAppId" '"PROGRESSIVE_MP4_APPID"'
 
-execute_no_payload $NODE_ID GetCameraStream true '"hls","dash","smooth_stream","progressive_mp4"'
+execute $NODE_ID GetCameraStream true '"hls","dash","smooth_stream","progressive_mp4"'
 test_out ".payload.commands[0].states.online" true
 test_out ".payload.commands[0].states.cameraStreamAccessUrl" '"http://PROGRESSIVE_MP4"'
 test_out ".payload.commands[0].states.cameraStreamProtocol" '"progressive_mp4"'
 test_out ".payload.commands[0].states.cameraStreamAuthToken" '"Auth Token"'
 test_out ".payload.commands[0].states.cameraStreamReceiverAppId" '"PROGRESSIVE_MP4_APPID"'
 
-execute_no_payload $NODE_ID GetCameraStream true '"hls"'
+execute $NODE_ID GetCameraStream true '"hls"'
 test_out ".payload.commands[0].states.online" true
 test_out ".payload.commands[0].states.cameraStreamAccessUrl" '"http://HLS"'
 test_out ".payload.commands[0].states.cameraStreamProtocol" '"hls"'
 test_out ".payload.commands[0].states.cameraStreamAuthToken" '"Auth Token"'
 test_out ".payload.commands[0].states.cameraStreamReceiverAppId" '"HLS_APPID"'
 
-execute_no_payload $NODE_ID GetCameraStream true '"dash"'
+execute $NODE_ID GetCameraStream true '"dash"'
 test_out ".payload.commands[0].states.online" true
 test_out ".payload.commands[0].states.cameraStreamAccessUrl" '"http://DASH"'
 test_out ".payload.commands[0].states.cameraStreamProtocol" '"dash"'
 test_out ".payload.commands[0].states.cameraStreamAuthToken" '"Auth Token"'
 test_out ".payload.commands[0].states.cameraStreamReceiverAppId" '"DASH_APPID"'
 
-execute_no_payload $NODE_ID GetCameraStream true '"smooth_stream"'
+execute $NODE_ID GetCameraStream true '"smooth_stream"'
 test_out ".payload.commands[0].states.online" true
 test_out ".payload.commands[0].states.cameraStreamAccessUrl" '"http://SMOOTH_STREAM"'
 test_out ".payload.commands[0].states.cameraStreamProtocol" '"smooth_stream"'

--- a/test/sh/flows.json
+++ b/test/sh/flows.json
@@ -300,7 +300,7 @@
         "smooth_stream_app_id": "SMOOTH_STREAM_APPID",
         "progressive_mp4": "http://PROGRESSIVE_MP4",
         "progressive_mp4_app_id": "PROGRESSIVE_MP4_APPID",
-        "auth_token": "Auth Token",
+        "auth_token": "Auth Token GUI",
         "passthru": true,
         "trait_scene": true,
         "scene_reversible": true,
@@ -435,6 +435,7 @@
             "PM10",
             "VolatileOrganicCompounds"
         ],
+        "arm_levels_ordered": true,
         "trait_fill": true,
         "available_fill_levels_file": "availableFillLevels.json",
         "supports_fill_percent": false,
@@ -842,6 +843,64 @@
         "payloadType": "json",
         "x": 140,
         "y": 440,
+        "wires": [
+            [
+                "a5782b1b.e120f8"
+            ]
+        ]
+    },
+    {
+        "id": "39c0b7dd.7494c8",
+        "type": "inject",
+        "z": "c0151475.218f98",
+        "name": "CameraStreamAuthToken",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": "10",
+        "topic": "CameraStreamAuthToken",
+        "payload": "Auth Token",
+        "payloadType": "str",
+        "x": 150,
+        "y": 600,
+        "wires": [
+            [
+                "a5782b1b.e120f8"
+            ]
+        ]
+    },
+    {
+        "id": "e0237e8.572fe8",
+        "type": "inject",
+        "z": "c0151475.218f98",
+        "name": "No CameraStreamAuthToken",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": "10",
+        "topic": "CameraStreamAuthToken",
+        "payload": "",
+        "payloadType": "str",
+        "x": 160,
+        "y": 640,
         "wires": [
             [
                 "a5782b1b.e120f8"


### PR DESCRIPTION
Hi,
this patch allows changing the camera auth token in the device node and when a device node receives a GetCameraStream command, send it in the output.