### PR TITLE
set_state message

### DIFF
--- a/devices/device.js
+++ b/devices/device.js
@@ -254,7 +254,7 @@ module.exports = function (RED) {
             this.target_temp_reached_estimate_unix_timestamp_sec = 360;
             this.thermostat_humidity_ambient = 60;
             // Timer 
-            this.max_timer_limit_sec = parseInt(config.max_timer_limit_sec) || 60;
+            this.max_timer_limit_sec = parseInt(config.max_timer_limit_sec) || 86400;
             this.command_only_timer = config.command_only_timer;
             this.timer_end_timestamp = -1;
             // Toggles

--- a/devices/device.js
+++ b/devices/device.js
@@ -234,9 +234,9 @@ module.exports = function (RED) {
             this.available_zones = config.available_zones;
             // StatusReport 
             // TemperatireControl
-            this.tc_min_threshold_celsius = config.tc_min_threshold_celsius;
-            this.tc_max_threshold_celsius = config.tc_max_threshold_celsius;
-            this.tc_temperature_step_celsius = config.tc_temperature_step_celsius;
+            this.tc_min_threshold_celsius = parseInt(config.tc_min_threshold_celsius) || 0;
+            this.tc_max_threshold_celsius = parseInt(config.tc_max_threshold_celsius) || 40;
+            this.tc_temperature_step_celsius = parseInt(config.tc_temperature_step_celsius) || 1;
             this.tc_temperature_unit_for_ux = config.tc_temperature_unit_for_ux;
             this.command_only_temperaturecontrol = config.tc_command_query_temperaturecontrol === 'command';
             this.query_only_temperaturecontrol = config.tc_command_query_temperaturecontrol === 'query';

--- a/devices/device.js
+++ b/devices/device.js
@@ -183,8 +183,8 @@ module.exports = function (RED) {
             this.ordered_inputs = config.ordered_inputs;
             this.current_input_index = -1;
             // LightEffects 
-            this.default_sleep_duration = config.default_sleep_duration;
-            this.default_wake_duration = config.default_wake_duration;
+            this.default_sleep_duration = parseInt(config.default_sleep_duration) || 1800;
+            this.default_wake_duration = parseInt(config.default_wake_duration) || 1800;
             this.supported_effects = config.supported_effects;
             // Locator 
             // LockUnlock 

--- a/devices/device.js
+++ b/devices/device.js
@@ -254,7 +254,7 @@ module.exports = function (RED) {
             this.target_temp_reached_estimate_unix_timestamp_sec = 360;
             this.thermostat_humidity_ambient = 60;
             // Timer 
-            this.max_timer_limit_sec = config.max_timer_limit_sec;
+            this.max_timer_limit_sec = parseInt(config.max_timer_limit_sec) || 60;
             this.command_only_timer = config.command_only_timer;
             this.timer_end_timestamp = -1;
             // Toggles

--- a/devices/device.js
+++ b/devices/device.js
@@ -632,7 +632,7 @@ module.exports = function (RED) {
 
             this.on('input', this.onInput);
             this.on('close', this.onClose);
-            this.clientConn.app.ScheduuleRequestSync();
+            this.clientConn.app.ScheduleRequestSync();
         }
 
         _debug(msg) {
@@ -1801,7 +1801,7 @@ module.exports = function (RED) {
                         RED.log.error("Applications disabled");
                     }
                     this.device.properties.attributes.availableApplications = this.available_applications;
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'AVAILABLEARMLEVELS') {
                     if (this.trait.armdisarm) {
                         if (typeof msg.payload === 'undefined') {
@@ -1817,7 +1817,7 @@ module.exports = function (RED) {
                         RED.log.error("Arm levels disabled");
                     }
                     this.device.properties.attributes.availableArmLevels.levels = this.available_arm_levels;
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'AVAILABLECHANNELS') {
                     if (this.trait.channel) {
                         if (typeof msg.payload === 'undefined') {
@@ -1833,7 +1833,7 @@ module.exports = function (RED) {
                         RED.log.error("Channels disabled");
                     }
                     this.device.properties.attributes.availableChannels = this.available_channels;
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'SUPPORTEDDISPENSEITEMS') {
                     if (this.trait.dispense) {
                         if (typeof msg.payload === 'undefined') {
@@ -1850,7 +1850,7 @@ module.exports = function (RED) {
                     }
                     this.device.properties.attributes.supportedDispenseItems = this.supported_dispense_items;
                     this.states['dispenseItems'] = this.getDispenseNewState();
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'SUPPORTEDDISPENSEPRESETS') {
                     if (this.trait.dispense) {
                         if (typeof msg.payload === 'undefined') {
@@ -1867,7 +1867,7 @@ module.exports = function (RED) {
                     }
                     this.device.properties.attributes.supportedDispensePresets = this.supported_dispense_presets;
                     this.states['dispenseItems'] = this.getDispenseNewState();
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'AVAILABLEFANSPEEDS') {
                     if (this.trait.fanspeed) {
                         if (typeof msg.payload === 'undefined') {
@@ -1883,7 +1883,7 @@ module.exports = function (RED) {
                         RED.log.error("Fan speeds disabled");
                     }
                     this.device.properties.attributes.availableFanSpeeds.speeds = this.available_fan_speeds;
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'AVAILABLEFILLLEVELS') {
                     if (this.trait.dispense) {
                         if (typeof msg.payload === 'undefined') {
@@ -1899,7 +1899,7 @@ module.exports = function (RED) {
                         RED.log.error("Fill levels disabled");
                     }
                     this.device.properties.attributes.availableFillLevels.levels = this.available_fill_levels;
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'AVAILABLEFOODPRESETS') {
                     if (this.trait.cook) {
                         if (typeof msg.payload === 'undefined') {
@@ -1915,7 +1915,7 @@ module.exports = function (RED) {
                         RED.log.error("Food presets disabled");
                     }
                     this.device.properties.attributes.foodPresets = this.food_presets;
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'AVAILABLEINPUTS') {
                     if (this.trait.inputselector) {
                         if (typeof msg.payload === 'undefined') {
@@ -1931,7 +1931,7 @@ module.exports = function (RED) {
                         RED.log.error("Inputs disabled");
                     }
                     this.device.properties.attributes.availableInputs = this.available_inputs;
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'AVAILABLEMODES') {
                     if (this.trait.modes) {
                         if (typeof msg.payload === 'undefined') {
@@ -1949,7 +1949,7 @@ module.exports = function (RED) {
                     }
                     this.device.properties.attributes.availableModes = this.available_modes;
                     this.updateModesState(me, me);
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'AVAILABLETOGGLES') {
                     if (this.trait.toggles) {
                         if (typeof msg.payload === 'undefined') {
@@ -1967,7 +1967,7 @@ module.exports = function (RED) {
                     }
                     this.device.properties.attributes.availableToggles = this.available_toggles;
                     this.updateTogglesState(me, me);
-                    this.clientConn.app.ScheduuleRequestSync();
+                    this.clientConn.app.ScheduleRequestSync();
                 } else if (upper_topic === 'CAMERASTREAMAUTHTOKEN') {
                     const auth_token = formats.FormatValue(formats.Formats.STRING, 'cameraStreamAuthToken', msg.payload) || "";
                     if (auth_token != me.auth_token) {
@@ -1976,7 +1976,7 @@ module.exports = function (RED) {
                             let cameraStreamNeedAuthToken = this.device.properties.attributes.cameraStreamNeedAuthToken;
                             if (cameraStreamNeedAuthToken != (auth_token.length > 0)) {
                                 this.device.properties.attributes['cameraStreamNeedAuthToken'] = auth_token.length > 0;
-                                this.clientConn.app.ScheduuleRequestSync();
+                                this.clientConn.app.ScheduleRequestSync();
                             }
                         }
                     }
@@ -2121,6 +2121,7 @@ module.exports = function (RED) {
                     if (me.updateState({ currentStatusReport: new_payload }) || differs) {
                         this.clientConn.setState(this, me.states, true);  // tell Google ...
 
+                        this.clientConn.app.ScheduleGetState();
                         if (this.passthru) {
                             msg.payload = new_payload;
                             this.send(msg);
@@ -2142,6 +2143,7 @@ module.exports = function (RED) {
                         if (differs) {
                             me._debug(".input: " + state_key + ' ' + JSON.stringify(msg.payload));
                             this.clientConn.setState(this, me.states, true);  // tell Google ...
+                            this.clientConn.app.ScheduleGetState();
 
                             if (this.passthru) {
                                 msg.payload = me.states[state_key];
@@ -2155,6 +2157,7 @@ module.exports = function (RED) {
 
                         if (differs) {
                             this.clientConn.setState(this, me.states, true);  // tell Google ...
+                            this.clientConn.app.ScheduleGetState();
 
                             if (this.passthru) {
                                 msg.payload = me.states;

--- a/google-smarthome.html
+++ b/google-smarthome.html
@@ -181,38 +181,6 @@
     </fieldset>
 </script>
 
-<script type="text/x-red" data-help-name="googlesmarthome-client">
-    <b>Local Authentication</b><br>
-    <code>Use Google login</code>: If enabled, use the Google login authentication.<br>
-    <code>Login Client ID</code>: If Google Login is enabled, the client id you gained from the *Google Sign-In* integration.<br>
-    <code>Authorized emails</code>: If Google Login is enabled, The email addresses authorized to log in.<br>
-    <code>Username</code> and <code>Password</code>: A username and password used when you link Google SmartHome to this node.<br>
-    <code>Access Token Duration</code>: The authorization token duration (in minutes) used by Google SmartHome to identify itself to node-red SmartHome plugin. Defaults is 60 minutes.<br>
-    <br>
-    <b>Actions on Google Project Settings</b><br>
-    <code>Client ID</code>: The client id you entered in the <b>Google on Actions</b> project.<br>
-    <code>Client Secret</code>: The client secret you entered in the <b>Google on Actions</b> project.<br>
-    <br>
-    <b>Google HomeGraph Settings</b><br>
-    <code>Jwt Key</code>: Full path to JWT key file.<br>
-    <code>Report Interval (m)</code>: Time, in minutes, between report updates are sent to Google.<br>
-    <br>
-    <b>Web Server Settings</b><br>
-    <code>Use http Node-RED root path</code>: If enabled, use the same http root path prefix configured for Node-RED, otherwise use /.<br>
-    <code>Path</code>: Prefix for URLs provided by this module. Default fulfillment URL is https://example.com:3001/smarthome. With a
-          path of "foo" this changes to https://example.com:3001/foo/smarthome. Same for URLs `/oauth` and `/token`.<br>
-    <code>Port</code>: TCP port of your choosing for incoming connections from Google. Must match what you entered in the <b>Google on Actions</b> project.<br>
-    <code>External SSL offload</code>: If enabled, SSL encryption is not used by the node and must be done elsewhere.
-    <code>Public Key</code>: Full path to public key file, e.g. `fullchain.pem` from Let's Encrypt.<br>
-    <code>Private Key</code>: Full path to private key file, e.g. `privkey.pem` from Let's Encrypt.<br>
-    <b>Advanced Settings</b><br>
-    <code>Request sync delay</code>: Delay for request devices sync after a deploy (default value 10).<br>
-    <code>Set state delay</code>: Delay for sending the set_state message after state changes (default value 30).<br>
-
-    <h3>References</h3>
-    <p><a href="https://www.npmjs.com/package/node-red-contrib-google-smarthome" target="_new">Node Information</a>.</p>
-</script>
-
 <script type="text/javascript">
     RED.nodes.registerType('googlesmarthome-client', {
         category: 'config',
@@ -471,84 +439,6 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="googlesmarthome.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]lgooglesmarthome.placeholder.name">
     </div>
-</script>
-
-<script type="text/x-red" data-help-name="google-mgmt">
-    <p>Allows to manage the Google Smart Home service.</p>
-
-    <h3>Inputs</h3>
-        <dl class="message-properties">
-            <dt>topic
-                <span class="property-type">string</span>
-            </dt>
-            <dd>Command to run. Can be restart_server, report_state, request_sync, get_state or set_state.</dd>
-        </dl>
-
-     <h3>Output</h3>
-        <dl class="message-properties">
-            <dt>payload
-                <span class="property-type">object</span>
-            </dt>
-            <dd>Debug messages from Google Smart Home service or the state of all Google Devices (with set_state or get_state topic).</dd>
-        </dl>
-
-    <h3>Details</h3>
-        <h4>Node Properties - Google SmartHome Settings</h4>
-        <p><code>SmartHome</code> Configuration node.</p>
-        <h4>Node Properties - Node-RED Settings</h4>
-        <p><code>Name</code> Name used by Google Smart Home.</p>
-
-        <h4>Input Messages</h4>
-        <p>If <code>msg.topic</code> is <code>restart_server</code> the built-in webserver will be restarted. Can be used when your SSL certificate has been renewed and needs to be re-read by the webserver.</p>
-        <dl class="message-properties">
-            <dt>topic
-                <span class="property-type">string</span>
-            </dt>
-            <dd>A topic of <code>restart_server</code> restarts the built-in webserver. <code>msg.payload</code> is not used for anything.</dd>
-        </dl>
-
-        <p>If <code>msg.topic</code> is <code>report_state</code> an update of all device states will be sent to Google. Mostly useful for debugging.</p>
-        <dl class="message-properties">
-            <dt>topic
-                <span class="property-type">string</span>
-            </dt>
-            <dd>A topic of <code>report_state</code> will send an update of all states to Google. <code>msg.payload</code> is not used for anything.</dd>
-        </dl>
-
-        <p>If <code>msg.topic</code> is <code>request_sync</code> Google is requested to sync to learn about new or changed devices. This usually happens automatically.</p>
-        <dl class="message-properties">
-            <dt>topic
-                <span class="property-type">string</span>
-            </dt>
-            <dd>A topic of <code>request_sync</code> requests Google to sync to learn about new or changed devices. <code>msg.payload</code> is not used for anything.</dd>
-        </dl>
-
-        <p>If <code>msg.topic</code> is <code>get_state</code> the node send a message in output with all the Google device state.</p>
-        <dl class="message-properties">
-            <dt>topic
-                <span class="property-type">string</span>
-            </dt>
-            <dd>A topic of <code>get_state</code> requests to send to the output the state of all Google devices. <code>msg.payload</code> is not used for anything.</dd>
-        </dl>
-
-        <p>If <code>msg.topic</code> is <code>set_state</code> the node updates the Google devices states with the states contained on the <code>msg.payload</code>.</p>
-        <dl class="message-properties">
-            <dt>topic
-                <span class="property-type">string</span>
-            </dt>
-            <dd>A topic of <code>set_state</code> updates the Google devices states with the value of the <code>msg.payload</code>.</dd>
-        </dl>
-
-        <h4>Output Messages</h4>
-        <p>This node will output debug messages if something goes wrong or the state of all Google Devices (with set_state or get_state topic).</p>
-        <dl class="message-properties">
-            <dt>payload
-                <span class="property-type">string|object</span>
-            </dt>
-            <dd>This node will output debug messages if something goes wrong or the state of all Google Devices (with set_state or get_state topic).</dd>
-        </dl>
-
-        <p>If a device state changes, the node output a message with the <code>msg.topic</code> set to <code>set_state</code>, and the <code>msg.payload</code> contains all the Google devices states that can be persisted if needed. This message can be passed into the node to restore the persisted state.</p>
 </script>
 
 <script type="text/javascript">

--- a/google-smarthome.html
+++ b/google-smarthome.html
@@ -205,6 +205,9 @@
     <code>External SSL offload</code>: If enabled, SSL encryption is not used by the node and must be done elsewhere.
     <code>Public Key</code>: Full path to public key file, e.g. `fullchain.pem` from Let's Encrypt.<br>
     <code>Private Key</code>: Full path to private key file, e.g. `privkey.pem` from Let's Encrypt.<br>
+    <b>Advanced Settings</b><br>
+    <code>Request sync delay</code>: Delay for request devices sync after a deploy (default value 10).<br>
+    <code>Set state delay</code>: Delay for sending the set_state message after state changes (default value 30).<br>
 
     <h3>References</h3>
     <p><a href="https://www.npmjs.com/package/node-red-contrib-google-smarthome" target="_new">Node Information</a>.</p>

--- a/google-smarthome.html
+++ b/google-smarthome.html
@@ -342,7 +342,7 @@
                 removable: true,
                 sortable: true
             });
-            let emails = this.emails || this.credentials.emails;
+            let emails = this.credentials.emails;
             if (typeof emails === 'string') {
                 emails = emails.split(";");
             }

--- a/google-smarthome.html
+++ b/google-smarthome.html
@@ -449,7 +449,7 @@
             <dt>topic
                 <span class="property-type">string</span>
             </dt>
-            <dd>Command to run. Can be restart_server, report_state or request_sync.</dd>
+            <dd>Command to run. Can be restart_server, report_state, request_sync, get_state or set_state.</dd>
         </dl>
 
      <h3>Output</h3>
@@ -457,7 +457,7 @@
             <dt>payload
                 <span class="property-type">object</span>
             </dt>
-            <dd>Debug messages from Google Smart Home service.</dd>
+            <dd>Debug messages from Google Smart Home service or the state of all Google Devices (with set_state or get_state topic).</dd>
         </dl>
 
     <h3>Details</h3>
@@ -491,14 +491,32 @@
             <dd>A topic of <code>request_sync</code> requests Google to sync to learn about new or changed devices. <code>msg.payload</code> is not used for anything.</dd>
         </dl>
 
+        <p>If <code>msg.topic</code> is <code>get_state</code> the node send a message in output with all the Google device state.</p>
+        <dl class="message-properties">
+            <dt>topic
+                <span class="property-type">string</span>
+            </dt>
+            <dd>A topic of <code>get_state</code> requests to send to the output the state of all Google devices. <code>msg.payload</code> is not used for anything.</dd>
+        </dl>
+
+        <p>If <code>msg.topic</code> is <code>set_state</code> the node updates the Google devices states with the states contained on the <code>msg.payload</code>.</p>
+        <dl class="message-properties">
+            <dt>topic
+                <span class="property-type">string</span>
+            </dt>
+            <dd>A topic of <code>set_state</code> updates the Google devices states with the value of the <code>msg.payload</code>.</dd>
+        </dl>
+
         <h4>Output Messages</h4>
-        <p>This node will output debug messages if something goes wrong.</p>
+        <p>This node will output debug messages if something goes wrong or the state of all Google Devices (with set_state or get_state topic).</p>
         <dl class="message-properties">
             <dt>payload
                 <span class="property-type">string|object</span>
             </dt>
-            <dd>This node will output debug messages if something goes wrong.</dd>
+            <dd>This node will output debug messages if something goes wrong or the state of all Google Devices (with set_state or get_state topic).</dd>
         </dl>
+
+        <p>If a device state changes, the node output a message with the <code>msg.topic</code> set to <code>set_state</code>, and the <code>msg.payload</code> contains all the Google devices states that can be persisted if needed. This message can be passed into the node to restore the persisted state.</p>
 </script>
 
 <script type="text/javascript">

--- a/google-smarthome.html
+++ b/google-smarthome.html
@@ -164,6 +164,21 @@
             </div>
         </div>
     </fieldset>
+    <fieldset>
+        <legend data-i18n="googlesmarthome.label.advanced_settings"></legend>
+
+        <div class="form-row">
+            <label for="node-config-input-request_sync_delay"><i class="fa fa-globe"></i> <span data-i18n="googlesmarthome.label.request_sync_delay"></span></label>
+            <input type="text" id="node-config-input-request_sync_delay" data-i18n="[placeholder]googlesmarthome.placeholder.request_sync_delay">
+        </div>
+
+
+        <div class="form-row">
+            <label for="node-config-input-set_state_delay"><i class="fa fa-globe"></i> <span data-i18n="googlesmarthome.label.set_state_delay"></span></label>
+            <input type="text" id="node-config-input-set_state_delay" data-i18n="[placeholder]googlesmarthome.placeholder.set_state_delay">
+        </div>
+
+    </fieldset>
 </script>
 
 <script type="text/x-red" data-help-name="googlesmarthome-client">
@@ -298,6 +313,20 @@
                 value:"", required:true
             }
             */
+            request_sync_delay: {
+                value:10, required:true, validate: function (v) {
+                    const n = parseInt(v);
+                    const f = parseFloat(v);
+                    return !isNaN(v) && Number.isInteger(f) && n >= 0;
+                }
+            },
+            set_state_delay: {
+                value:30, required:true, validate: function (v) {
+                    const n = parseInt(v);
+                    const f = parseFloat(v);
+                    return !isNaN(v) && Number.isInteger(f) && n >= 0;
+                }
+            }
         },
 
         credentials: {

--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -303,6 +303,16 @@ module.exports = function(RED) {
             }
         };
 
+        this.sendSetState = function () {
+            let states = this.clientConn.app.getStates();
+            if (states) {
+                this.send({
+                    topic: 'set_state',
+                    payload: states
+                });
+            };
+        }
+
         this.on('input', this.onInput);
 
         this.on('close', function(removed, done) {

--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -141,7 +141,7 @@ module.exports = function(RED) {
         };
 
         this.on('close', function(removed, done) {
-            node.app.Stop(done);
+            node.app.Stop(RED.httpNode || RED.httpAdmin, done);
             
             if (removed) {
                 // this node has been deleted
@@ -278,7 +278,7 @@ module.exports = function(RED) {
                 if (topic.toUpperCase() === 'RESTART_SERVER') {
                     RED.log.debug("MgmtNode(input): RESTART_SERVER");
 
-                    this.clientConn.app.Restart();
+                    this.clientConn.app.Restart(RED.httpNode || RED.httpAdmin);
                 } else if (topic.toUpperCase() === 'REPORT_STATE') {
                     RED.log.debug("MgmtNode(input): REPORT_STATE");
 

--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -62,6 +62,8 @@ module.exports = function(RED) {
             node.credentials.clientid || '', 
             node.credentials.clientsecret || '',
             config.reportinterval,     // minutes
+            parseInt(config.request_sync_delay || '10'),
+            parseInt(config.set_state_delay || '0'),
             config.enabledebug);
 
         let err = this.app.Start(RED.httpNode || RED.httpAdmin);

--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -264,7 +264,7 @@ module.exports = function(RED) {
          * respond to inputs from NodeRED
          *
          */
-        this.on('input', function (msg) {
+        this.onInput = function (msg) {
             RED.log.debug("MgmtNode(input)");
 
             let topicArr = msg.topic.split(node.topicDelim);
@@ -301,7 +301,9 @@ module.exports = function(RED) {
             } catch (err) {
                 RED.log.error(err);
             }
-        });
+        };
+
+        this.on('input', this.onInput);
 
         this.on('close', function(removed, done) {
             if (removed) {

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -60,6 +60,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
         this._userDir               = userDir;
         this._httpServerRunning     = false;
         this._syncScheduled         = false;
+        this._getStateScheduled     = false;
 
         this.loadAuth(nodeId, userDir, username || 'dummy');
         this.setClientIdSecret(clientid, clientsecret);
@@ -240,14 +241,27 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     //
     //
-    ScheduuleRequestSync() {
+    ScheduleRequestSync() {
         const me = this;
         if (!me._syncScheduled) {
             me._syncScheduled = true;
             setTimeout(() => {
                 me._syncScheduled = false;
                 me.requestSync();
-            }, 10000);
+            }, 10000);      // TODO delay configurable
+        }
+    }
+    //
+    //
+    //
+    ScheduleGetState() {
+        const me = this;
+        if (!me._getStateScheduled) {
+            me._getStateScheduled = true;
+            setTimeout(() => {
+                me._getStateScheduled = false;
+                Object.keys(me._mgmtNode.mgmtNodes).forEach(key => me._mgmtNode.mgmtNodes[key].onInput({topic: 'get_state'}));
+            }, 30000);      // TODO delay configurable
         }
     }
     //

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -176,17 +176,31 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     //
     //
-    Stop(done) {
+    Stop(REDapp, done) {
         let me = this;
         if (this._reportStateTimer !== null) {
             clearTimeout(this._reportStateTimer);
             this._reportStateTimer  = null;
         }
 
-        if (this._httpServerRunning) {
-            this._httpServerRunning = false;
+        if (this._httpsPort > 0) {
+            if (this._httpServerRunning) {
+                this._httpServerRunning = false;
 
-            this.httpServer.stop(function() {
+                this.httpServer.stop(function() {
+                    process.nextTick(() => {
+                        me.emitter.emit('server', 'stop', 0);
+                    });
+
+                    if (typeof done === 'function') {
+                        done();
+                    }
+                });
+
+                setImmediate(function(){
+                    me.httpServer.emit('close');
+                });
+            } else {
                 process.nextTick(() => {
                     me.emitter.emit('server', 'stop', 0);
                 });
@@ -194,12 +208,24 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
                 if (typeof done === 'function') {
                     done();
                 }
-            });
-
-            setImmediate(function(){
-                me.httpServer.emit('close');
-            });
+            }
         } else {
+            var get_urls = [path.join(me._httpPath, 'oauth'), path.join(me._httpPath, 'check')];
+            var post_urls = [path.join(me._httpPath, 'oauth'), path.join(me._httpPath, 'smarthome')];
+            var options_urls = [path.join(me._httpPath, 'smarthome')];
+            var all_urls = [path.join(me._httpPath, 'token')];
+
+            REDapp._router.stack.forEach(function (route, i, routes) {
+                if (route.route && (
+                    (route.route.methods['get'] && get_urls.includes(route.route.path)) ||
+                    (route.route.methods['post'] && post_urls.includes(route.route.path)) ||
+                    (route.route.methods['options'] && options_urls.includes(route.route.path)) ||
+                    (all_urls.includes(route.route.path))
+                )) {
+                    me._mgmtNode.debug('SmartHome:Stop(): removing url: ' + route.route.path);
+                    routes.splice(i, 1);
+                }
+            });
             process.nextTick(() => {
                 me.emitter.emit('server', 'stop', 0);
             });
@@ -212,13 +238,13 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     //
     //
-    Restart() {
+    Restart(REDapp) {
         let me = this;
 
-        this.Stop(function() {
+        this.Stop(REDapp, function() {
             me.debug('SmartHome:Restart(): Stop done');
 
-            me.Start();
+            me.Start(REDapp);
 
             me.debug('SmartHome:Restart(): Start done');
         });

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -88,8 +88,8 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
             // frontend UI
             this.app.set('jsonp callback name', 'cid');
 
-            this.httpAuthRegister(path.join(usehttpnoderoot ? this._httpNodeRoot : '/', this._httpPath));        // login and oauth http interface
-            this.httpActionsRegister(path.join(usehttpnoderoot ? this._httpNodeRoot : '/', this._httpPath));     // actual SmartHome http interface
+            this.httpAuthRegister(path.join((usehttpnoderoot ? this._httpNodeRoot || '/': '/'), this._httpPath));        // login and oauth http interface
+            this.httpActionsRegister(path.join((usehttpnoderoot ? this._httpNodeRoot || '/' : '/'), this._httpPath));     // actual SmartHome http interface
         }
     }
     //
@@ -163,9 +163,11 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
                     }
                 });
             } else {
-                me.debug("SmartHome:Start(): use the Node-RED server port, path " + path.join(this._httpNodeRoot, this._httpPath));
-                this.httpAuthRegister(this._httpPath, REDapp);        // login and oauth http interface
-                this.httpActionsRegister(this._httpPath, REDapp);     // actual SmartHome http interface
+                if (this._httpNodeRoot !== false) {
+                    me.debug("SmartHome:Start(): use the Node-RED server port, path " + path.join(this._httpNodeRoot, this._httpPath));
+                    this.httpAuthRegister(this._httpPath, REDapp);        // login and oauth http interface
+                    this.httpActionsRegister(this._httpPath, REDapp);     // actual SmartHome http interface
+                }
             }
         } catch (err) {
             return err;
@@ -210,22 +212,24 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
                 }
             }
         } else {
-            var get_urls = [path.join(me._httpPath, 'oauth'), path.join(me._httpPath, 'check')];
-            var post_urls = [path.join(me._httpPath, 'oauth'), path.join(me._httpPath, 'smarthome')];
-            var options_urls = [path.join(me._httpPath, 'smarthome')];
-            var all_urls = [path.join(me._httpPath, 'token')];
+            if (this._httpNodeRoot !== false) {
+                var get_urls = [path.join(me._httpPath, 'oauth'), path.join(me._httpPath, 'check')];
+                var post_urls = [path.join(me._httpPath, 'oauth'), path.join(me._httpPath, 'smarthome')];
+                var options_urls = [path.join(me._httpPath, 'smarthome')];
+                var all_urls = [path.join(me._httpPath, 'token')];
 
-            REDapp._router.stack.forEach(function (route, i, routes) {
-                if (route.route && (
-                    (route.route.methods['get'] && get_urls.includes(route.route.path)) ||
-                    (route.route.methods['post'] && post_urls.includes(route.route.path)) ||
-                    (route.route.methods['options'] && options_urls.includes(route.route.path)) ||
-                    (all_urls.includes(route.route.path))
-                )) {
-                    me._mgmtNode.debug('SmartHome:Stop(): removing url: ' + route.route.path);
-                    routes.splice(i, 1);
-                }
-            });
+                REDapp._router.stack.forEach(function (route, i, routes) {
+                    if (route.route && (
+                        (route.route.methods['get'] && get_urls.includes(route.route.path)) ||
+                        (route.route.methods['post'] && post_urls.includes(route.route.path)) ||
+                        (route.route.methods['options'] && options_urls.includes(route.route.path)) ||
+                        (all_urls.includes(route.route.path))
+                    )) {
+                        me._mgmtNode.debug('SmartHome:Stop(): removing url: ' + route.route.path);
+                        routes.splice(i, 1);
+                    }
+                });
+            }
             process.nextTick(() => {
                 me.emitter.emit('server', 'stop', 0);
             });

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -260,7 +260,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
             me._getStateScheduled = true;
             setTimeout(() => {
                 me._getStateScheduled = false;
-                Object.keys(me._mgmtNode.mgmtNodes).forEach(key => me._mgmtNode.mgmtNodes[key].onInput({topic: 'get_state'}));
+                Object.keys(me._mgmtNode.mgmtNodes).forEach(key => me._mgmtNode.mgmtNodes[key].sendSetState());
             }, 30000);      // TODO delay configurable
         }
     }

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -43,7 +43,7 @@ const HttpActions   = require('./HttpActions.js');
 class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) {
     constructor(mgmtNode, nodeId, userDir, httpNodeRoot, useGoogleLogin, googleClientId, emails, username, password, accessTokenDuration, usehttpnoderoot,
         httpPath, httpsPort, ssloffload, publicKey, privateKey, jwtkey, clientid, 
-        clientsecret, reportStateInterval, debug) {
+        clientsecret, reportStateInterval, requestSyncDelay, setStateDelay, debug) {
         super();
 
         this._mgmtNode              = mgmtNode;
@@ -56,6 +56,8 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
         this._publicKey             = publicKey;
         this._privateKey            = privateKey;
         this._jwtKey                = jwtkey;
+        this._requestSyncDelay      = requestSyncDelay * 1000;
+        this._setStateDelay         = setStateDelay * 1000;
         this._debug                 = debug;
         this._userDir               = userDir;
         this._httpServerRunning     = false;
@@ -248,7 +250,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
             setTimeout(() => {
                 me._syncScheduled = false;
                 me.requestSync();
-            }, 10000);      // TODO delay configurable
+            }, me._requestSyncDelay);
         }
     }
     //
@@ -256,12 +258,12 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     ScheduleGetState() {
         const me = this;
-        if (!me._getStateScheduled) {
+        if (me._setStateDelay && !me._getStateScheduled) {
             me._getStateScheduled = true;
             setTimeout(() => {
                 me._getStateScheduled = false;
                 Object.keys(me._mgmtNode.mgmtNodes).forEach(key => me._mgmtNode.mgmtNodes[key].sendSetState());
-            }, 30000);      // TODO delay configurable
+            }, me._setStateDelay);
         }
     }
     //

--- a/lib/frontend/login.html
+++ b/lib/frontend/login.html
@@ -235,7 +235,6 @@
             }
 
             if (params.get('error')) {
-                console.log("CCHI ERRORE " + params.get("error"));
                 document.getElementById('error_invalid_user').style.display = 'block';
             }
         });

--- a/locales/en-US/google-smarthome.html
+++ b/locales/en-US/google-smarthome.html
@@ -1,0 +1,130 @@
+<!--
+ NodeRED Google SmartHome
+ Copyright (C) 2021 Michael Jacobsen.
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script type="text/x-red" data-help-name="googlesmarthome-client">
+    <b>Local Authentication</b><br>
+    <code>Use Google login</code>: If enabled, use the Google login authentication.<br>
+    <code>Login Client ID</code>: If Google Login is enabled, the client id you gained from the *Google Sign-In* integration.<br>
+    <code>Authorized emails</code>: If Google Login is enabled, The email addresses authorized to log in.<br>
+    <code>Username</code> and <code>Password</code>: A username and password used when you link Google SmartHome to this node.<br>
+    <code>Access Token Duration</code>: The authorization token duration (in minutes) used by Google SmartHome to identify itself to node-red SmartHome plugin. Defaults is 60 minutes.<br>
+    <br>
+    <b>Actions on Google Project Settings</b><br>
+    <code>Client ID</code>: The client id you entered in the <b>Google on Actions</b> project.<br>
+    <code>Client Secret</code>: The client secret you entered in the <b>Google on Actions</b> project.<br>
+    <br>
+    <b>Google HomeGraph Settings</b><br>
+    <code>Jwt Key</code>: Full path to JWT key file.<br>
+    <code>Report Interval (m)</code>: Time, in minutes, between report updates are sent to Google.<br>
+    <br>
+    <b>Web Server Settings</b><br>
+    <code>Use http Node-RED root path</code>: If enabled, use the same http root path prefix configured for Node-RED, otherwise use /.<br>
+    <code>Path</code>: Prefix for URLs provided by this module. Default fulfillment URL is https://example.com:3001/smarthome. With a
+          path of "foo" this changes to https://example.com:3001/foo/smarthome. Same for URLs `/oauth` and `/token`.<br>
+    <code>Port</code>: TCP port of your choosing for incoming connections from Google. Must match what you entered in the <b>Google on Actions</b> project.<br>
+    <code>External SSL offload</code>: If enabled, SSL encryption is not used by the node and must be done elsewhere.
+    <code>Public Key</code>: Full path to public key file, e.g. `fullchain.pem` from Let's Encrypt.<br>
+    <code>Private Key</code>: Full path to private key file, e.g. `privkey.pem` from Let's Encrypt.<br>
+    <b>Advanced Settings</b><br>
+    <code>Request sync delay</code>: Delay for request devices sync after a deploy (default value 10).<br>
+    <code>Set state delay</code>: Delay for sending the set_state message after state changes (default value 30).<br>
+
+    <h3>References</h3>
+    <p><a href="https://www.npmjs.com/package/node-red-contrib-google-smarthome" target="_new">Node Information</a>.</p>
+</script>
+
+<!--
+    Management Interface
+-->
+<script type="text/x-red" data-help-name="google-mgmt">
+    <p>Allows to manage the Google Smart Home service.</p>
+
+    <h3>Inputs</h3>
+        <dl class="message-properties">
+            <dt>topic
+                <span class="property-type">string</span>
+            </dt>
+            <dd>Command to run. Can be restart_server, report_state, request_sync, get_state or set_state.</dd>
+        </dl>
+
+     <h3>Output</h3>
+        <dl class="message-properties">
+            <dt>payload
+                <span class="property-type">object</span>
+            </dt>
+            <dd>Debug messages from Google Smart Home service or the state of all Google Devices (with set_state or get_state topic).</dd>
+        </dl>
+
+    <h3>Details</h3>
+        <h4>Node Properties - Google SmartHome Settings</h4>
+        <p><code>SmartHome</code> Configuration node.</p>
+        <h4>Node Properties - Node-RED Settings</h4>
+        <p><code>Name</code> Name used by Google Smart Home.</p>
+
+        <h4>Input Messages</h4>
+        <p>If <code>msg.topic</code> is <code>restart_server</code> the built-in webserver will be restarted. Can be used when your SSL certificate has been renewed and needs to be re-read by the webserver.</p>
+        <dl class="message-properties">
+            <dt>topic
+                <span class="property-type">string</span>
+            </dt>
+            <dd>A topic of <code>restart_server</code> restarts the built-in webserver. <code>msg.payload</code> is not used for anything.</dd>
+        </dl>
+
+        <p>If <code>msg.topic</code> is <code>report_state</code> an update of all device states will be sent to Google. Mostly useful for debugging.</p>
+        <dl class="message-properties">
+            <dt>topic
+                <span class="property-type">string</span>
+            </dt>
+            <dd>A topic of <code>report_state</code> will send an update of all states to Google. <code>msg.payload</code> is not used for anything.</dd>
+        </dl>
+
+        <p>If <code>msg.topic</code> is <code>request_sync</code> Google is requested to sync to learn about new or changed devices. This usually happens automatically.</p>
+        <dl class="message-properties">
+            <dt>topic
+                <span class="property-type">string</span>
+            </dt>
+            <dd>A topic of <code>request_sync</code> requests Google to sync to learn about new or changed devices. <code>msg.payload</code> is not used for anything.</dd>
+        </dl>
+
+        <p>If <code>msg.topic</code> is <code>get_state</code> the node send a message in output with all the Google device state.</p>
+        <dl class="message-properties">
+            <dt>topic
+                <span class="property-type">string</span>
+            </dt>
+            <dd>A topic of <code>get_state</code> requests to send to the output the state of all Google devices. <code>msg.payload</code> is not used for anything.</dd>
+        </dl>
+
+        <p>If <code>msg.topic</code> is <code>set_state</code> the node updates the Google devices states with the states contained on the <code>msg.payload</code>.</p>
+        <dl class="message-properties">
+            <dt>topic
+                <span class="property-type">string</span>
+            </dt>
+            <dd>A topic of <code>set_state</code> updates the Google devices states with the value of the <code>msg.payload</code>.</dd>
+        </dl>
+
+        <h4>Output Messages</h4>
+        <p>This node will output debug messages if something goes wrong or the state of all Google Devices (with set_state or get_state topic).</p>
+        <dl class="message-properties">
+            <dt>payload
+                <span class="property-type">string|object</span>
+            </dt>
+            <dd>This node will output debug messages if something goes wrong or the state of all Google Devices (with set_state or get_state topic).</dd>
+        </dl>
+
+        <p>If a device state changes, the node output a message with the <code>msg.topic</code> set to <code>set_state</code>, and the <code>msg.payload</code> contains all the Google devices states that can be persisted if needed. This message can be passed into the node to restore the persisted state.</p>
+</script>

--- a/locales/en-US/google-smarthome.json
+++ b/locales/en-US/google-smarthome.json
@@ -34,7 +34,10 @@
             "pt-BR": "Portuguese",
             "es": "Spanish",
             "sv": "Swedish",
-            "th": "Thai"
+            "th": "Thai",
+            "advanced_settings": "Advanced settings",
+            "request_sync_delay": "Request sync delay",
+            "set_state_delay": "set_state message delay"
         },
         "placeholder": {
             "name": "Name",
@@ -46,7 +49,9 @@
             "accesstokenduration": "Interval in minutes",
             "port": "Server port. -1 or empty for the Node-RED port",
             "reportinterval": "Interval in minutes. -1 to disable",
-            "emails": "Semicolon separated authorized emails"
+            "emails": "Semicolon separated authorized emails",
+            "request_sync_delay": "Delay for request sync after a deploy",
+            "set_state_delay": "Delay for sending the set_state message after state changes"
         },
         "state": {
             "connected": "Connected to broker: __broker__",

--- a/locales/it_IT/google-smarthome.json
+++ b/locales/it_IT/google-smarthome.json
@@ -34,7 +34,10 @@
 			"pt-BR": "Portughese",
 			"es": "Spagnolo",
 			"sv": "Svedese",
-			"th": "Tailandese"
+			"th": "Tailandese",
+            "advanced_settings": "Impostazioni avanzate",
+            "request_sync_delay": "Ritardo richiesta di sincronizzazione",
+            "set_state_delay": "Ritardo invio del messaggio set_state"
         },
         "placeholder": {
             "name": "Nome",


### PR DESCRIPTION
Hi,
the patch allows the management node to send a set_state message if a device state change (after some delay). 

This message can be persisted if needed and can be passed into the management node to restore the persisted state.

There are the following two timers:

- after 10 seconds of a node deployment, request sync is sent to Google in order to align all the devices' properties. 
- after 30 seconds of a state update (state change), a "set_state" message is sent to the management node output to allow the save the new state.

I'm not sure if I should insert those timers' duration in the configuration GUI?

Thanks

