### PR TITLE
sync a dummy node if no nodes exist

### DIFF
--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -273,6 +273,32 @@ class HttpActions {
             }
         });
 
+        if (deviceList.length === 0) {
+            deviceList.push({
+				type: "action.devices.types.SCENE",
+				traits: [
+					"action.devices.traits.Scene"
+				],
+				name: {
+					defaultNames: [
+						"Node-RED Scene"
+					],
+					name: "Dummy"
+				},
+				willReportState: true,
+				attributes: {
+					sceneReversible: false
+				},
+				deviceInfo: {
+					manufacturer: "Node-RED",
+					model: "nr-device-scene-v1",
+					swVersion: "1.0",
+					hwVersion: "1.0"
+				},
+				id: "dummy.node"
+			});
+        }
+
         let deviceProps = {
             requestId: requestId,
             payload: {


### PR DESCRIPTION
This PR sync a dummy node (Google device scene) if no nodes exist.
This should prevent the link error in case no nodes exist.