### PR TITLE
Added the Persistent State flag

### DIFF
--- a/devices/baseDevice.js
+++ b/devices/baseDevice.js
@@ -104,6 +104,7 @@ class BaseDevice {
         };
         this.topicOut = config.topic;
         this.passthru = config.passthru;
+        this.persistent_state = config.persistent_state || false;
         this.room_hint = config.room_hint;
         this.device_type = config.device_type;
 

--- a/devices/baseDevice.js
+++ b/devices/baseDevice.js
@@ -1818,15 +1818,19 @@ class BaseDevice {
                     text = thermostat_mode.substr(0, 1).toUpperCase() + st;
                 }
                 if (me.states.thermostatHumidityAmbient !== undefined) {
-                    text += ' ' + me.states.thermostatHumidityAmbient + "% ";
+                    text += ' ' + me.states.thermostatHumidityAmbient + "%";
                 }
             }
             if (me.trait.energystorage) {
                 text += ' ' + me.states.descriptiveCapacityRemaining;
             }
             if (me.trait.armdisarm) {
-                if (me.states.currentArmLevel) {
-                    text += ' ' + me.states.currentArmLevel;
+                if (me.states.isArmed)  {
+                    if (me.states.currentArmLevel) {
+                        text += ' ' + me.states.currentArmLevel;
+                    }
+                } else {
+                    text += ' DISARMED';
                 }
             }
         } else {

--- a/devices/baseDevice.js
+++ b/devices/baseDevice.js
@@ -2299,8 +2299,9 @@ class BaseDevice {
                 });
                 if (me.updateState({ currentStatusReport: new_payload }) || differs) {
                     me.clientConn.setState(me, me.states, true);  // tell Google ...
-
-                    me.clientConn.app.ScheduleGetState();
+                    if (me.persistent_state) {
+                        me.clientConn.app.ScheduleGetState();
+                    }
                     // if (me.passthru) {
                     //     msg.payload = new_payload;
                     //     me.send(msg);
@@ -2468,7 +2469,9 @@ class BaseDevice {
                     //     me.send({ topic: me.topicOut, payload: me.states });
                     // }
                     me.clientConn.setState(me, me.states, true);  // tell Google ...
-                    me.clientConn.app.ScheduleGetState();
+                    if (me.persistent_state) {
+                        me.clientConn.app.ScheduleGetState();
+                    }
                     me.updateStatusIcon();
                 }
                 if (me.passthru) {

--- a/devices/device.html
+++ b/devices/device.html
@@ -2207,7 +2207,7 @@
                 value: false, required: false
             },
             persistent_state: {
-                value: true, required: false
+                value: false, required: false
             },
             trait_scene: {
                 value: false, required: false

--- a/devices/device.html
+++ b/devices/device.html
@@ -62,6 +62,11 @@
         <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> <span data-i18n="device.label.passthru"></span></label>
         <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
+
+    <div class="form-row">
+        <label style="width:auto" for="node-input-persistent_state"><i class="fa fa-arrow-right"></i> <span data-i18n="device.label.persistent_state"></span></label>
+        <input type="checkbox" checked id="node-input-persistent_state" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
     
     <div class="form-row" id="device_type">
         <label style="width:auto" for="node-input-device_type"><i class="fa fa-tag"></i> <span data-i18n="device.label.device_type"></span></label>
@@ -2200,6 +2205,9 @@
             },
             passthru: {
                 value: false, required: false
+            },
+            persistent_state: {
+                value: true, required: false
             },
             trait_scene: {
                 value: false, required: false

--- a/devices/locales/en-US/device.html
+++ b/devices/locales/en-US/device.html
@@ -162,11 +162,11 @@
 
         <p><code>Pass Through</code> If enabled, incoming messages will be passed onto the output. Be careful with this setting.</p>
 
-        <p><code>Language</code> the spoken language used with the Google Smart Home.</p>
+        <p><code>Persistent state</code> If enabled, the updated state will be included in the set_state message.</p>
 
-        <p><code>Show trait</code> choose to show the selected, recommended or all traits.</p>
+        <p><code>Show trait</code> Choose to show the selected, recommended or all traits.</p>
 
-        <p><code>Advanced settings</code> shows the advanced settings. Don't modify them unless You know what you are doing.</p>
+        <p><code>Advanced settings</code> Shows the advanced settings. Don't modify them unless You know what you are doing.</p>
 
         <h4>Input Message</h4>
         <p>If the <code>msg.topic</code> is one of the device states name the <code>msg.payload</code> must be the new value telling the new state of the device.</p>

--- a/devices/locales/en-US/device.json
+++ b/devices/locales/en-US/device.json
@@ -231,7 +231,8 @@
             "no_challenge": "No challenge",
             "ackNeeded": "Ack needed",
             "pinNeeded": "PIN needed",
-            "pin": "PIN"
+            "pin": "PIN",
+            "persistent_state": "Persistent state"
         },
         "placeholder": {
             "name": "Name",

--- a/devices/locales/it-IT/device.html
+++ b/devices/locales/it-IT/device.html
@@ -162,11 +162,11 @@
 
         <p><code>Pass Through</code> If enabled, incoming messages will be passed onto the output. Be careful with this setting.</p>
 
-        <p><code>Language</code> the spoken language used with the Google Smart Home.</p>
+        <p><code>Persistent state</code> If enabled, the updated state will be included in the set_state message.</p>
 
-        <p><code>Show trait</code> choose to show the selected, recommended or all traits.</p>
+        <p><code>Show trait</code> Choose to show the selected, recommended or all traits.</p>
 
-        <p><code>Advanced settings</code> shows the advanced settings. Don't modify them unless You know what you are doing.</p>
+        <p><code>Advanced settings</code> Shows the advanced settings. Don't modify them unless You know what you are doing.</p>
 
         <h4>Input Message</h4>
         <p>If the <code>msg.topic</code> is one of the device states name the <code>msg.payload</code> must be the new value telling the new state of the device.</p>

--- a/devices/locales/it-IT/device.json
+++ b/devices/locales/it-IT/device.json
@@ -250,7 +250,8 @@
             "no_challenge": "Nessuna",
             "ackNeeded": "Si/No",
             "pinNeeded": "PIN",
-            "pin": "PIN"
+            "pin": "PIN",
+            "persistent_state": "Stato persistente"
 		},
 		"placeholder": {
 			"name": "Nome",

--- a/google-smarthome.js
+++ b/google-smarthome.js
@@ -288,7 +288,7 @@ module.exports = function(RED) {
 
                     this.clientConn.app.RequestSync();
                 } else if (topic.toUpperCase() === 'GET_STATE') {
-                    let states = this.clientConn.app.getStates();
+                    let states = this.clientConn.app.getStates(undefined, msg.payload || false, RED);
                     if (states) {
                         this.send({
                             topic: topic,
@@ -306,7 +306,7 @@ module.exports = function(RED) {
         };
 
         this.sendSetState = function () {
-            let states = this.clientConn.app.getStates();
+            let states = this.clientConn.app.getStates(undefined, true, RED);
             if (states) {
                 this.send({
                     topic: 'set_state',

--- a/lib/Devices.js
+++ b/lib/Devices.js
@@ -265,7 +265,7 @@ class Devices {
     //
     //
     //
-    getStates(deviceIds, onlyPersistent, RED) {
+    getStates(deviceIds, onlyPersistent, useNames, RED) {
         this.debug('Device:getStates(): deviceIds = ' + JSON.stringify(deviceIds));
 
         if (!deviceIds || !Object.keys(deviceIds).length) {
@@ -280,12 +280,16 @@ class Devices {
             Object.keys(me._devices).forEach(function (deviceId) {
                 if (me._devices.hasOwnProperty(deviceId)) {
                     let include = true;
-                    if (onlyPersistent === true) {
+                    let key = deviceId;
+                    if (onlyPersistent === true || useNames === true) {
                         let node = RED.nodes.getNode(deviceId);
                         include = node.persistent_state;
+                        if (useNames === true) {
+                            key = node.name;
+                        }
                     } 
                     if (include) {
-                        states[deviceId] = me._devices[deviceId].states;
+                        states[key] = me._devices[deviceId].states;
                     }
                 }
             });

--- a/lib/Devices.js
+++ b/lib/Devices.js
@@ -280,15 +280,12 @@ class Devices {
             Object.keys(me._devices).forEach(function (deviceId) {
                 if (me._devices.hasOwnProperty(deviceId)) {
                     let include = true;
-                    let name = undefined;
                     if (onlyPersistent === true) {
                         let node = RED.nodes.getNode(deviceId);
                         include = node.persistent_state;
-                        name = node.name;
                     } 
                     if (include) {
                         states[deviceId] = me._devices[deviceId].states;
-                        states[deviceId].name = name;
                     }
                 }
             });

--- a/lib/Devices.js
+++ b/lib/Devices.js
@@ -265,7 +265,7 @@ class Devices {
     //
     //
     //
-    getStates(deviceIds) {
+    getStates(deviceIds, onlyPersistent, RED) {
         this.debug('Device:getStates(): deviceIds = ' + JSON.stringify(deviceIds));
 
         if (!deviceIds || !Object.keys(deviceIds).length) {
@@ -279,7 +279,17 @@ class Devices {
         if (!deviceIds) {
             Object.keys(me._devices).forEach(function (deviceId) {
                 if (me._devices.hasOwnProperty(deviceId)) {
-                    states[deviceId] = me._devices[deviceId].states;
+                    let include = true;
+                    let name = undefined;
+                    if (onlyPersistent === true) {
+                        let node = RED.nodes.getNode(deviceId);
+                        include = node.persistent_state;
+                        name = node.name;
+                    } 
+                    if (include) {
+                        states[deviceId] = me._devices[deviceId].states;
+                        states[deviceId].name = name;
+                    }
                 }
             });
         } else {

--- a/locales/en-US/google-smarthome.html
+++ b/locales/en-US/google-smarthome.html
@@ -106,7 +106,7 @@
             <dt>topic
                 <span class="property-type">string</span>
             </dt>
-            <dd>A topic of <code>get_state</code> requests to send to the output the state of all Google devices. <code>msg.payload</code> is not used for anything.</dd>
+            <dd>A topic of <code>get_state</code> requests to send to the output the state of all Google devices, if the <code>msg.payload</code> is not true, otherwise sends to the output the state of all Google devices with the "Persistent State" enabled.</dd>
         </dl>
 
         <p>If <code>msg.topic</code> is <code>set_state</code> the node updates the Google devices states with the states contained on the <code>msg.payload</code>.</p>

--- a/locales/it_IT/google-smarthome.html
+++ b/locales/it_IT/google-smarthome.html
@@ -105,7 +105,7 @@
             <dt>topic
                 <span class="property-type">stringa</span>
             </dt>
-            <dd>Se un messaggio con topic <code>get_state</code> è ricevuto, il nodo invierà un messaggio in uscita con lo stato di tutti i dispositivi. <code>msg.payload</code> non è usato.</dd>
+            <dd>Se un messaggio con topic <code>get_state</code> è ricevuto, il nodo invierà un messaggio in uscita con lo stato di tutti i dispositivi, se <code>msg.payload</code> non è valorizzato a true, altrimenti il nodo invierà un messaggio in uscita con lo stato di tutti i dispositivi che hanno il campo "Stato persistente" abilitato.</dd>
         </dl>
 
         <p>Se il <code>msg.topic</code> è <code>set_state</code>, il nodo aggiorna lo stato di tutti i dispositivi con lo stato contenuto  nel <code>msg.payload</code>. Questo messaggio può essere usato per salvare su un dispositivo di memorizzazione lo stato di tutti i dispositivi.</p>


### PR DESCRIPTION
This PR adds the flag "Persistent State" to the device node. In this way, only the enabled node state will be included in the set_state message sent from the management node.
I've also added a parameter to the get_state message to the management node, if the payload is true, only the state of the nodes with the "Persistent State" flag enabled will be included in the output.
This should simplify the solution of the #227 
