### PR TITLE
camera and media devices deprecation warning

### DIFF
--- a/devices/camera.html
+++ b/devices/camera.html
@@ -20,7 +20,7 @@
     Camera
 -->
 <script type="text/x-red" data-template-name="google-camera">
-    <div class="form-tips">
+    <div class="form-tips" style="border: red 1px solid;">
         <b>This device is deprecated. Please use the Google Device node instead.</b>
     </div><br>
 
@@ -185,6 +185,9 @@
             },
             name: {
                 value: "", required:true
+            },
+            deprecated: {
+                value: "", required:true, validate: (v) => false
             },
             topic: {
                 value: "", required: false

--- a/devices/media.html
+++ b/devices/media.html
@@ -20,7 +20,7 @@
     Media
 -->
 <script type="text/x-red" data-template-name="google-media">
-    <div class="form-tips">
+    <div class="form-tips" style="border: red 1px solid;">
         <b>This device is deprecated. Please use the Google Device node instead.</b>
     </div><br>
 
@@ -534,6 +534,9 @@
             },
             name: {
                 value: "", required:true
+            },
+            deprecated: {
+                value: "", required:true, validate: (v) => false
             },
             topic: {
                 value: "", required: false


### PR DESCRIPTION
With this PR, the Camera and Media Devices nodes will have a RED triangle, showing that the nodes are deprecated, like the following:

![image](https://user-images.githubusercontent.com/2863760/149764486-df1ae5ae-04e3-47d7-b78b-bb019a6c9d51.png)

![image](https://user-images.githubusercontent.com/2863760/149764571-b6e187e1-ac06-484d-89a1-6260fee6134a.png)

This should speed up the migration progress.

