### PR TITLE
ScheduleGetState

### DIFF
--- a/devices/baseDevice.js
+++ b/devices/baseDevice.js
@@ -814,7 +814,7 @@ class BaseDevice {
                     swVersion: '1.0',
                     hwVersion: '1.0'
                 },
-                otherDeviceIds: [{deviceId: client.id}],
+                otherDeviceIds: [{ deviceId: client.id }],
                 customData: this.clientConn.app.getCustomData()
             }
         };
@@ -2070,6 +2070,9 @@ class BaseDevice {
         const modified = me.updateState(params || states, me.states, me.state_types);
         if (modified) {
             this.cloneObject(states, me.states, me.state_types);
+            //if (me.persistent_state) {
+                me.clientConn.app.ScheduleGetState();
+            //}
         }
 
         this.updateStatusIcon();


### PR DESCRIPTION
This PR should enable to send the SetState after the node receives a command from Google.
Unfortunately in the "updated" function seems that this is not equal to the node object, so "me.persistent_state" is undefined.
After removing all the deprecated nodes, we can change the general code to fix #205.