### PR TITLE
Improve node-RED contrib node compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "node-red"
   ],
   "node-red": {
+    "version": ">=2.0.0",
     "nodes": {
       "google-smarthome": "google-smarthome.js",
       "device": "devices/device.js",
@@ -37,6 +38,9 @@
       "vaccum": "devices/vacuum.js",
       "window": "devices/window.js"
     }
+  },
+    "engines": {
+    "node": ">=12.0.0"
   },
   "author": {
     "name": "Michael Jacobsen"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node-red"
   ],
   "node-red": {
-    "version": ">=2.0.0",
+    "version": ">=1.3.0",
     "nodes": {
       "google-smarthome": "google-smarthome.js",
       "device": "devices/device.js",
@@ -40,7 +40,7 @@
     }
   },
     "engines": {
-    "node": ">=12.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "Michael Jacobsen"


### PR DESCRIPTION
node-RED has introduced a quality check (scoreboard rating) to indicate that contrib nodes are reaching the minimum specs expected by the node-RED team.
I added an example flow previously (1 point when the depreciated nodes have been removed), and these two additions will improve the SH score by a further 2 points.
See https://discourse.nodered.org/t/introducing-node-scorecards-and-a-new-node-naming-convention/57559/28

For consideration...