### PR TITLE
local_smarthome path replaced by the original smarthome path

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@ Google Workspace account. If this is the case, you can share access to your smar
 - Set a port for local fulfillment in the management node's config.
 - If you have set a domain on your host, check the configuration. /etc/hostname must only contain the hostname without
   the domain. /etc/hosts must contain a line for your hostname including the domain.
-- Send an HTTP POST request to `http://192.168.178.25:13002/local_smarthome` (with the IP address of your host and the
-  port you chose). E.g. run `curl -X POST http://192.168.178.25:13002/local_smarthome`. It should answer with
+- Send an HTTP POST request to `http://192.168.178.25:13002/smarthome` (with the IP address of your host and the
+  port you chose). E.g. run `curl -X POST http://192.168.178.25:13002/smarthome`. It should answer with
   `{"error":"missing inputs"}`. This error message is okay, all other messages indicate connection problems with the
   local fulfillment service.
 - Install an app like [mDNS Discovery](https://play.google.com/store/apps/details?id=com.mdns_discovery.app) on your

--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -42,7 +42,9 @@ class Auth {
         this._jwtkey         = null;
         this._accessTokenDuration = 60;
         this._tokenGen       = new TokenGenerator(256, TokenGenerator.BASE58);
-        this._localAuthCode  = this.genRandomString();
+        this._localAuthCode  = null;
+        this._clearAllTokens();
+        this.generateLocalAccessToken();
     }
     //
     //
@@ -323,6 +325,12 @@ class Auth {
     //
     //
     //
+    isValidLocalAccessToken(accessToken) {
+        return accessToken === this._localAuthCode;
+    }
+    //
+    //
+    //
     getuserForAccessToken(accessToken) {
         if (accessToken === this._localAuthCode) {
             return "local execution";
@@ -392,21 +400,32 @@ class Auth {
     getAuth() {
         return this._auth;
     }
+    //
+    //
+    //
+    generateLocalAccessToken() {
+        this._localAuthCode = this._generateNewAccessToken();
+        return this._localAuthCode;
+    }
     /******************************************************************************************************************
      * private methods
      *
      */
-    _generateAccessToken(user) {
+     _generateNewAccessToken() {
         while (true) {
             let accessToken = this.genRandomString();
-            if (typeof this._auth.accessTokens[accessToken] == 'undefined') {
-                this._auth.accessTokens[accessToken] = {
-                    user: user,
-                    expiresAt: Date.now() + (this._accessTokenDuration * 60000),
-                };
+            if (accessToken !== this._localAuthCode && typeof this._auth.accessTokens[accessToken] == 'undefined') {
                 return accessToken;
             }
         }
+    }
+    _generateAccessToken(user) {
+        let accessToken = this._generateNewAccessToken();
+        this._auth.accessTokens[accessToken] = {
+            user: user,
+            expiresAt: Date.now() + (this._accessTokenDuration * 60000),
+        };
+        return accessToken;
     }
     //
     _generateRefreshToken(user) {

--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -42,6 +42,7 @@ class Auth {
         this._jwtkey         = null;
         this._accessTokenDuration = 60;
         this._tokenGen       = new TokenGenerator(256, TokenGenerator.BASE58);
+        this._localAuthCode  = this.genRandomString();
     }
     //
     //
@@ -167,6 +168,12 @@ class Auth {
         }
 
         return true;
+    }
+    //
+    //
+    //
+    getLocalAuthCode() {
+        return this._localAuthCode;
     }
     //
     //
@@ -317,6 +324,9 @@ class Auth {
     //
     //
     getuserForAccessToken(accessToken) {
+        if (accessToken === this._localAuthCode) {
+            return "local execution";
+        }
         const accessTokenInfo = this._auth.accessTokens[accessToken];
         if (typeof accessTokenInfo === 'undefined') {
             this.debug('Auth:isValidAccessToken(): accessToken = ' + JSON.stringify(accessToken) + ' not found.');

--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -42,9 +42,7 @@ class Auth {
         this._jwtkey         = null;
         this._accessTokenDuration = 60;
         this._tokenGen       = new TokenGenerator(256, TokenGenerator.BASE58);
-        this._localAuthCode  = null;
         this._clearAllTokens();
-        this.generateLocalAccessToken();
     }
     //
     //
@@ -68,12 +66,16 @@ class Auth {
             } else {
                 me.debug('Auth:loadAuth(): data already persisted');
                 me._auth = JSON.parse(authFile);
+                if (me._auth.localAuthCode === undefined) {
+                    this.generateLocalAccessToken();
+                }
                 me.debug('Auth:loadAuth(): me._auth = ' + JSON.stringify(me._auth));
             }
             me._persistAuth();
         }
         catch (err) {
             me.error('Error on loading auth storage: ' + err.toString());
+            me._clearAllTokens();
             process.nextTick(() => {
                 me.emitter.emit('auth', 'error', err);
             });
@@ -175,7 +177,7 @@ class Auth {
     //
     //
     getLocalAuthCode() {
-        return this._localAuthCode;
+        return this._auth.localAuthCode;
     }
     //
     //
@@ -326,13 +328,13 @@ class Auth {
     //
     //
     isValidLocalAccessToken(accessToken) {
-        return accessToken === this._localAuthCode;
+        return accessToken === this._auth.localAuthCode;
     }
     //
     //
     //
     getuserForAccessToken(accessToken) {
-        if (accessToken === this._localAuthCode) {
+        if (accessToken === this._auth.localAuthCode) {
             return "local execution";
         }
         const accessTokenInfo = this._auth.accessTokens[accessToken];
@@ -404,8 +406,8 @@ class Auth {
     //
     //
     generateLocalAccessToken() {
-        this._localAuthCode = this._generateNewAccessToken();
-        return this._localAuthCode;
+        this._auth.localAuthCode = this._generateNewAccessToken();
+        return this._auth.localAuthCode;
     }
     /******************************************************************************************************************
      * private methods
@@ -414,7 +416,7 @@ class Auth {
      _generateNewAccessToken() {
         while (true) {
             let accessToken = this.genRandomString();
-            if (accessToken !== this._localAuthCode && typeof this._auth.accessTokens[accessToken] == 'undefined') {
+            if (accessToken !== this._auth.localAuthCode && typeof this._auth.accessTokens[accessToken] == 'undefined') {
                 return accessToken;
             }
         }
@@ -479,8 +481,10 @@ class Auth {
     _clearAllTokens() {
         this._auth = { 
             "accessTokens" : {},
-            "refreshTokens" : {}
-        }
+            "refreshTokens" : {},
+            "localAuthCode": ''
+        };
+        this.generateLocalAccessToken();
     }
 }
 

--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -48,7 +48,7 @@ class Auth {
     //
     //
     loadAuth(nodeId, userDir, username) {
-        let me = this;
+        const me = this;
 
         try {
             me._authFilename = userDir + '/google-smarthome-auth-' + nodeId + '.json';
@@ -66,8 +66,14 @@ class Auth {
             } else {
                 me.debug('Auth:loadAuth(): data already persisted');
                 me._auth = JSON.parse(authFile);
-                if (me._auth.localAuthCode === undefined) {
-                    this.generateLocalAccessToken();
+                if (typeof me._auth !== 'object' || Array.isArray(me._auth)) {
+                    me._clearAllTokens();
+                }
+                if (!me._auth.localAuthCode) {
+                    me.generateLocalAccessToken();
+                }
+                if (!me._auth.nextLocalAuthCode) {
+                    me._auth.nextLocalAuthCode = this._generateNewAccessToken();
                 }
                 me.debug('Auth:loadAuth(): me._auth = ' + JSON.stringify(me._auth));
             }
@@ -177,7 +183,7 @@ class Auth {
     //
     //
     getLocalAuthCode() {
-        return this._auth.localAuthCode;
+        return this._auth.nextLocalAuthCode;
     }
     //
     //
@@ -328,13 +334,19 @@ class Auth {
     //
     //
     isValidLocalAccessToken(accessToken) {
+        if (accessToken === this._auth.nextLocalAuthCode) {
+            this._auth.localAuthCode = this._auth.nextLocalAuthCode;
+            this._auth.nextLocalAuthCode = this._generateNewAccessToken();
+            this._persistAuth();
+            return true;
+        }
         return accessToken === this._auth.localAuthCode;
     }
     //
     //
     //
     getuserForAccessToken(accessToken) {
-        if (accessToken === this._auth.localAuthCode) {
+        if (accessToken === this._auth.localAuthCode || accessToken === this._auth.nextLocalAuthCode) {
             return "local execution";
         }
         const accessTokenInfo = this._auth.accessTokens[accessToken];
@@ -407,6 +419,9 @@ class Auth {
     //
     generateLocalAccessToken() {
         this._auth.localAuthCode = this._generateNewAccessToken();
+        if (!this._auth.nextLocalAuthCode) {
+            this._auth.nextLocalAuthCode = this._generateNewAccessToken();
+        }
         return this._auth.localAuthCode;
     }
     /******************************************************************************************************************
@@ -416,7 +431,7 @@ class Auth {
      _generateNewAccessToken() {
         while (true) {
             let accessToken = this.genRandomString();
-            if (accessToken !== this._auth.localAuthCode && typeof this._auth.accessTokens[accessToken] == 'undefined') {
+            if (accessToken !== this._auth.localAuthCode && accessToken !== this._auth.nextLocalAuthCode && typeof this._auth.accessTokens[accessToken] == 'undefined') {
                 return accessToken;
             }
         }
@@ -482,7 +497,8 @@ class Auth {
         this._auth = { 
             "accessTokens" : {},
             "refreshTokens" : {},
-            "localAuthCode": ''
+            "localAuthCode": '',
+            "nextLocalAuthCode": ''
         };
         this.generateLocalAccessToken();
     }

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -195,6 +195,13 @@ class HttpActions {
 
             return;
         }
+        if (is_local_execution) {
+            if (!isLocalIP(request.ip)) {
+                response.status(200).set({
+                    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+                }).json({});
+            }
+        }
 
         me.debug('HttpActions:httpActionsRegister(/' + url + '): user: ' + user);
 
@@ -358,7 +365,7 @@ class HttpActions {
     _sync(requestId, response) {
         this.debug('HttpActions:_sync()');
 
-        this.generateLocalAccessToken();
+        // this.generateLocalAccessToken();
         let devices = this.getProperties();
         if (!devices) {
             response.status(500).set({

--- a/lib/HttpActions.js
+++ b/lib/HttpActions.js
@@ -18,13 +18,13 @@
 
 'use strict';
 
-const path           = require('path');
+const path = require('path');
 const TokenGenerator = require('uuid-token-generator');
-const {google}       = require('googleapis');
-const fs             = require('fs');
-const ipRangeCheck   = require('ip-range-check');
+const { google } = require('googleapis');
+const fs = require('fs');
+const ipRangeCheck = require('ip-range-check');
 
-const userId         = '0';
+const userId = '0';
 
 const LOOPBACK_NETWORKS = [
     "127.0.0.0/8",
@@ -38,7 +38,7 @@ const PRIVATE_NETWORKS = [
     "192.168.0.0/16"
 ];
 
-const isLocalIP = function(ip) {
+const isLocalIP = function (ip) {
     return ipRangeCheck(ip, LOOPBACK_NETWORKS) || ipRangeCheck(ip, PRIVATE_NETWORKS)
 };
 
@@ -67,6 +67,8 @@ class HttpActions {
          *       "action.devices.SYNC",
          *       "action.devices.QUERY",
          *       "action.devices.EXECUTE"
+         *       "action.devices.IDENTIFY",
+         *       "action.devices.REACHABLE_DEVICES",
          *     ]
          *   },
          *   httpExecution: "https://example.org/device/agent",
@@ -75,14 +77,14 @@ class HttpActions {
          *   }
          * }
          */
-        appHttp.post(me.Path_join(httpRoot, 'smarthome'), function(request, response) {
+        appHttp.post(me.Path_join(httpRoot, 'smarthome'), function (request, response) {
             me._post(request, response, 'smarthome');
         });
 
         /**
          * Endpoint to check HTTP(S) reachability.
          */
-        appHttp.get(me.Path_join(httpRoot, 'check'), function(request, response) {
+        appHttp.get(me.Path_join(httpRoot, 'check'), function (request, response) {
             me.debug('HttpActions:httpActionsRegister(/check)');
             if (me._debug) {
                 fs.readFile(path.join(__dirname, 'frontend/check.html'), 'utf8', function (err, data) {
@@ -102,16 +104,13 @@ class HttpActions {
         /**
          * Enables preflight (OPTIONS) requests made cross-domain.
          */
-        appHttp.options(me.Path_join(httpRoot, 'smarthome'), function(request, response) {
+        appHttp.options(me.Path_join(httpRoot, 'smarthome'), function (request, response) {
             me._options(request, response);
         });
     }
 
     httpLocalActionsRegister(httpLocalRoot, appHttp) {
         let me = this;
-        if (typeof appHttp === 'undefined') {
-            appHttp = this.localApp;
-        }
 
         /**
          *
@@ -126,20 +125,20 @@ class HttpActions {
          *   },
          * }
          */
-        appHttp.post(me.Path_join(httpLocalRoot, 'local_smarthome'), function(request, response) {
-            me.debug('local_smarthome: request.headers = ' + JSON.stringify(request.headers));
+        appHttp.post(me.Path_join(httpLocalRoot, 'smarthome'), function (request, response) {
+            me.debug('local smarthome: request.headers = ' + JSON.stringify(request.headers));
             if (!isLocalIP(request.ip)) {
                 response.status(200).set({
                     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
                 }).json({});
             }
-            me._post(request, response, 'local_smarthome');
+            me._post(request, response, 'smarthome');
         });
 
         /**
          * Enables preflight (OPTIONS) requests made cross-domain.
          */
-        appHttp.options(me.Path_join(httpLocalRoot, 'local_smarthome'), function(request, response) {
+        appHttp.options(me.Path_join(httpLocalRoot, 'smarthome'), function (request, response) {
             me._options(request, response);
         });
     }
@@ -161,58 +160,56 @@ class HttpActions {
 
         me.debug('HttpActions:httpActionsRegister(/' + url + '): request.headers = ' + JSON.stringify(request.headers));
         me.debug('HttpActions:httpActionsRegister(/' + url + '): reqdata = ' + JSON.stringify(reqdata));
-        
-        var user = '';
-        if (url != 'local_smarthome') {
-            let res = request.headers.authorization;
-            if (!res) {
-                me.error('HttpActions:httpActionsRegister(/' + url + '): missing authorization header; res = ' + JSON.stringify(res));
 
-                response.status(401).set({
-                    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-                }).json({error: 'missing inputs'});
+        let res = request.headers.authorization;
+        if (!res) {
+            me.error('HttpActions:httpActionsRegister(/' + url + '): missing authorization header; res = ' + JSON.stringify(res));
 
-                return;
-            }
-
-            res = res.split(" ");
-            if (res.length != 2 || res[0] != 'Bearer') {
-                me.error('HttpActions:httpActionsRegister(/' + url + '): invalid authorization data; res = ' + JSON.stringify(res));
-
-                response.status(401).set({
+            response.status(401).set({
                 'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-                }).json({error: 'missing inputs'});
+            }).json({ error: 'missing inputs' });
 
-                return;
-            }
-
-            let accessToken = res[1];
-            if (!me.isValidAccessToken(accessToken)) {
-                me.error('HttpActions:httpActionsRegister(/' + url + '): no accessToken found');
-
-                response.status(401).set({
-                'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-                }).json({error: 'missing inputs'});
-
-                return;
-            }
-
-            user = me.getuserForAccessToken(accessToken);
-            me.debug('HttpActions:httpActionsRegister(/' + url + '): user: ' + user);
+            return;
         }
+
+        res = res.split(" ");
+        if (res.length != 2 || res[0] != 'Bearer') {
+            me.error('HttpActions:httpActionsRegister(/' + url + '): invalid authorization data; res = ' + JSON.stringify(res));
+
+            response.status(401).set({
+                'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+            }).json({ error: 'missing inputs' });
+
+            return;
+        }
+
+        let accessToken = res[1];
+        const is_local_execution = me.isValidLocalAccessToken(accessToken);
+        const user = me.getuserForAccessToken(accessToken);
+        if (user === null) {
+            me.error('HttpActions:httpActionsRegister(/' + url + '): no accessToken found');
+
+            response.status(401).set({
+                'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+            }).json({ error: 'missing inputs' });
+
+            return;
+        }
+
+        me.debug('HttpActions:httpActionsRegister(/' + url + '): user: ' + user);
 
         if (!reqdata.inputs) {
             me.error('HttpActions:httpActionsRegister(/' + url + '): missing reqdata.inputs');
 
             response.status(401).set({
-              'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-            }).json({error: 'missing inputs'});
+                'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+            }).json({ error: 'missing inputs' });
 
             return;
         }
 
         for (let i = 0; i < reqdata.inputs.length; i++) {
-            let input  = reqdata.inputs[i];
+            let input = reqdata.inputs[i];
             let intent = input.intent;
 
             if (!intent) {
@@ -220,7 +217,7 @@ class HttpActions {
 
                 response.status(401).set({
                     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-                }).json({error: 'missing inputs'});
+                }).json({ error: 'missing inputs' });
 
                 continue;
             }
@@ -307,7 +304,7 @@ class HttpActions {
                      *   }]
                      * }
                      */
-                    me._exec(reqdata.requestId, reqdata.inputs[i].payload.commands, response, url == 'local_smarthome');
+                    me._exec(reqdata.requestId, reqdata.inputs[i].payload.commands, response, is_local_execution);
                     break;
 
                 case 'action.devices.DISCONNECT':
@@ -350,7 +347,7 @@ class HttpActions {
 
                     response.status(401).set({
                         'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-                    }).json({error: 'missing intent'});
+                    }).json({ error: 'missing intent' });
                     break;
             }
         }
@@ -361,11 +358,12 @@ class HttpActions {
     _sync(requestId, response) {
         this.debug('HttpActions:_sync()');
 
+        this.generateLocalAccessToken();
         let devices = this.getProperties();
         if (!devices) {
             response.status(500).set({
                 'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-            }).json({error: 'failed'});
+            }).json({ error: 'failed' });
 
             return;
         }
@@ -373,38 +371,38 @@ class HttpActions {
         let me = this;
         let deviceList = [];
 
-        Object.keys(devices).forEach(function(key) {
+        Object.keys(devices).forEach(function (key) {
             if (devices.hasOwnProperty(key) && devices[key]) {
                 let device = devices[key];
-                device.id  = key;
+                device.id = key;
                 deviceList.push(device);
             }
         });
 
         if (deviceList.length === 0) {
             deviceList.push({
-				type: "action.devices.types.SCENE",
-				traits: [
-					"action.devices.traits.Scene"
-				],
-				name: {
-					defaultNames: [
-						"Node-RED Scene"
-					],
-					name: "Dummy"
-				},
-				willReportState: true,
-				attributes: {
-					sceneReversible: false
-				},
-				deviceInfo: {
-					manufacturer: "Node-RED",
-					model: "nr-device-scene-v1",
-					swVersion: "1.0",
-					hwVersion: "1.0"
-				},
-				id: "dummy.node"
-			});
+                type: "action.devices.types.SCENE",
+                traits: [
+                    "action.devices.traits.Scene"
+                ],
+                name: {
+                    defaultNames: [
+                        "Node-RED Scene"
+                    ],
+                    name: "Dummy"
+                },
+                willReportState: true,
+                attributes: {
+                    sceneReversible: false
+                },
+                deviceInfo: {
+                    manufacturer: "Node-RED",
+                    model: "nr-device-scene-v1",
+                    swVersion: "1.0",
+                    hwVersion: "1.0"
+                },
+                id: "dummy.node"
+            });
         }
 
         let deviceProps = {
@@ -432,8 +430,8 @@ class HttpActions {
         let states = this.getStates(deviceIds);
         if (!states) {
             response.status(500).set({
-              'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-            }).json({error: 'failed'});
+                'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+            }).json({ error: 'failed' });
 
             return;
         }
@@ -502,7 +500,7 @@ class HttpActions {
 
         response.status(200).json(resBody);
 
-        return resBody;      
+        return resBody;
     }
     // Called by _exec
     //
@@ -518,14 +516,14 @@ class HttpActions {
         // check whether the device exists or whether it exists and it is disconnected.
         if (!cur_device || !cur_device.states.online) {
             me._mgmtNode.warn('HttpActions:_execDevice(): the device you want to control is offline');
-            return {status: 'ERROR', errorCode: 'deviceOffline'};
+            return { status: 'ERROR', errorCode: 'deviceOffline' };
         }
 
         let curDevice = {
             id: deviceId,
             states: {},
         };
-        
+
         curDevice.command = command.command;
         const result = cur_device.execCommand(command);
         if (result.hasOwnProperty('status')) {
@@ -542,7 +540,7 @@ class HttpActions {
             command.params = result.params;
             allParams = true;
         }
-        
+
         if (command.hasOwnProperty('params')) {
             Object.keys(command.params).forEach(function (key) {
                 if (allParams || cur_device.states.hasOwnProperty(key)) {
@@ -579,8 +577,8 @@ class HttpActions {
         let reachableDevices = this.getReachableDeviceIds();
         if (!reachableDevices) {
             response.status(500).set({
-              'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-            }).json({error: 'failed'});
+                'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+            }).json({ error: 'failed' });
 
             return;
         }
@@ -604,7 +602,7 @@ class HttpActions {
     //
     reportState(deviceId, states, notifications) {
         let me = this;
-        
+
         this.debug('HttpActions:reportState(): deviceId = ' + deviceId);
         if (states) {
             this.debug('HttpActions:reportState(): states = ' + JSON.stringify(states));
@@ -667,7 +665,7 @@ class HttpActions {
             auth: auth,
         });
 
-        homegraph.devices.reportStateAndNotification({'requestBody': postData})
+        homegraph.devices.reportStateAndNotification({ 'requestBody': postData })
             .then(result => {
                 me.debug('HttpActions:reportState(): success');
             })
@@ -721,7 +719,7 @@ class HttpActions {
             auth: auth,
         });
 
-        homegraph.devices.requestSync({'requestBody': postData})
+        homegraph.devices.requestSync({ 'requestBody': postData })
             .then(result => {
                 me.debug('HttpActions:requestSync(): success');
             })

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -41,7 +41,7 @@ const HttpActions   = require('./HttpActions.js');
  */
 class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) {
     constructor(mgmtNode, nodeId, userDir, httpNodeRoot, useGoogleLogin, googleClientId, emails, username, password, accessTokenDuration, usehttpnoderoot,
-        httpPath, httpsPort, httpLocalPort, nodeRedUsesHttps, ssloffload, publicKey, privateKey, jwtkey, clientid, 
+        httpPath, httpPort, httpLocalPort, nodeRedUsesHttps, ssloffload, publicKey, privateKey, jwtkey, clientid, 
         clientsecret, reportStateInterval, requestSyncDelay, setStateDelay, debug, debug_function, error_function) {
         super();
 
@@ -51,7 +51,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
         this._reportStateInterval   = reportStateInterval;  // minutes
         this._httpNodeRoot          = httpNodeRoot;
         this._httpPath              = this.Path_join('/', httpPath || '');
-        this._httpsPort             = httpsPort;
+        this._httpPort              = httpPort;
         this._httpLocalPort         = httpLocalPort;
         this._sslOffload            = ssloffload;
         this._publicKey             = publicKey;
@@ -87,39 +87,42 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
 
         this.emitter = new events.EventEmitter();
 
-        if (httpsPort > 0) {
-            // create express middleware
-            this.app = express();
-            this.app.use(helmet({ 
-                // opener policy required for Google Sign-In popup
-                crossOriginOpenerPolicy: { policy: "same-origin-allow-popups" }
-            }));
-            this.app.use(cors());
-            this.app.use(morgan('dev'));
-            this.app.use(express.json());
-            this.app.use(express.urlencoded({extended: true}));
-            this.app.set('trust proxy', 1); // trust first proxy
+        // httpNodeRoot is the root url for nodes that provide HTTP endpoints. If set to false, all node-based HTTP endpoints are disabled. 
+        if (this._httpNodeRoot !== false) {
+            if (httpPort > 0) {
+                // create express middleware
+                this.app = express();
+                this.app.use(helmet({ 
+                    // opener policy required for Google Sign-In popup
+                    crossOriginOpenerPolicy: { policy: "same-origin-allow-popups" }
+                }));
+                this.app.use(cors());
+                this.app.use(morgan('dev'));
+                this.app.use(express.json());
+                this.app.use(express.urlencoded({extended: true}));
+                this.app.set('trust proxy', 1); // trust first proxy
 
-            // frontend UI
-            this.app.set('jsonp callback name', 'cid');
+                // frontend UI
+                this.app.set('jsonp callback name', 'cid');
 
-            this.httpAuthRegister(this._httpPath, this.app);        // login and oauth http interface
-            this.httpActionsRegister(this._httpPath, this.app);     // actual SmartHome http interface
-        }
-        if (httpLocalPort > 0) {
-            // create express middleware
-            this.localApp = express();
-            this.localApp.use(helmet());
-            this.localApp.use(cors());
-            this.localApp.use(morgan('dev'));
-            this.localApp.use(express.json());
-            this.localApp.use(express.urlencoded({extended: true}));
-            this.localApp.set('trust proxy', 1); // trust first proxy
+                this.httpAuthRegister(this._httpPath, this.app);        // login and oauth http interface
+                this.httpActionsRegister(this._httpPath, this.app);     // actual SmartHome http interface
+            }
+            if (httpLocalPort > 0) {
+                // create express middleware
+                this.localApp = express();
+                this.localApp.use(helmet());
+                this.localApp.use(cors());
+                this.localApp.use(morgan('dev'));
+                this.localApp.use(express.json());
+                this.localApp.use(express.urlencoded({extended: true}));
+                this.localApp.set('trust proxy', 1); // trust first proxy
 
-            // frontend UI
-            this.localApp.set('jsonp callback name', 'cid');
+                // frontend UI
+                this.localApp.set('jsonp callback name', 'cid');
 
-            this.httpLocalActionsRegister(this._httpLocalPath, this.localApp);
+                this.httpLocalActionsRegister(this._httpLocalPath, this.localApp);
+            }
         }
     }
     //
@@ -159,11 +162,11 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     UnregisterUrl(REDapp) {
         const me = this;
 
-        if (this._httpNodeRoot !== false && REDapp._router) {
+        if (REDapp._router) {
             me.debug("SmartHome:UnregisterUrl(): use the Node-RED server port, path '" + this._httpPath + "' local path '" + this._httpLocalPath + "'");
             var get_urls = [me.Path_join(me._httpPath, 'oauth'), me.Path_join(me._httpPath, 'check')];
-            var post_urls = [me.Path_join(me._httpPath, 'oauth'), me.Path_join(me._httpPath, 'smarthome'), me.Path_join(me._httpLocalPath, 'local_smarthome')];
-            var options_urls = [me.Path_join(me._httpPath, 'smarthome'), me.Path_join(me._httpLocalPath, 'local_smarthome')];
+            var post_urls = [me.Path_join(me._httpPath, 'oauth'), me.Path_join(me._httpPath, 'smarthome')];
+            var options_urls = [me.Path_join(me._httpPath, 'smarthome')];
             var all_urls = [me.Path_join(me._httpPath, 'token')];
 
             let to_remove = [];
@@ -211,7 +214,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
         this.dnssdAd.start();
         this._dnssdAdRunning = true;
 
-        me.debug('SmartHome:Start(): dnssd-Ad: port:' + port);
+        me.debug('SmartHome:Start(): dnssd-ad: port:' + port);
         this.dnssdAd.on('error', function (err) {
             me.error('SmartHome:Start(): dnssd-ad: err:' + err);
 
@@ -224,6 +227,9 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     //
     Start(REDapp, REDserver) {
+        // httpNodeRoot is the root url for nodes that provide HTTP endpoints. If set to false, all node-based HTTP endpoints are disabled. 
+        if (this._httpNodeRoot === false) return;
+
         try {
             const graceMilliseconds = 500;
             const me                = this;
@@ -243,7 +249,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
                 }
             }
 
-            if (this._httpsPort > 0) {
+            if (this._httpPort > 0) {
                 if (this._sslOffload) {
                     me.debug('SmartHome:Start(listen): using external SSL offload');
 
@@ -263,7 +269,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
                 }
 
                 // start server
-                this.httpServer.listen(this._httpsPort, () => {
+                this.httpServer.listen(this._httpPort, () => {
                     me._httpServerRunning = true;
 
                     const host = me.httpServer.address().address;
@@ -272,7 +278,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
                     me.debug('SmartHome:Start(listen): listening at ' + host + ':' + port);
 
                     process.nextTick(() => {
-                        me.emitter.emit('server', 'start', me._httpsPort);
+                        me.emitter.emit('server', 'start', me._httpPort);
                     });
                 });
 
@@ -326,21 +332,17 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
                 });
                     
                 me.StartMDNSAdvertisement(this._httpLocalPort);
+            } else {
+                me.StartMDNSAdvertisement(REDserver.address().port);
             }
             
-            if (this._httpNodeRoot !== false && (this._httpsPort <= 0 || this._httpLocalPort <= 0)) {
+            if (this._httpPort <= 0) {
                 me.UnregisterUrl(REDapp);
 
-                if (this._httpsPort <= 0) {
+                if (this._httpPort <= 0) {
                     me.debug("SmartHome:Start(): use the Node-RED server port, path " + this._httpPath);
                     this.httpAuthRegister(this._httpPath, REDapp);        // login and oauth http interface
                     this.httpActionsRegister(this._httpPath, REDapp);     // actual SmartHome http interface
-                }
-
-                if (this._httpLocalPort <= 0) {
-                    this.httpLocalActionsRegister(this._httpLocalPath, REDapp); // local smarthome interface (always HTTP!)
-                    
-                    me.StartMDNSAdvertisement(REDserver.address().port);
                 }
 
                 REDapp._router.stack.forEach((r) => {
@@ -359,6 +361,9 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     //
     Stop(REDapp, done) {
+        // httpNodeRoot is the root url for nodes that provide HTTP endpoints. If set to false, all node-based HTTP endpoints are disabled. 
+        if (this._httpNodeRoot === false) return;
+
         const me = this;
         if (this._reportStateTimer !== null) {
             clearTimeout(this._reportStateTimer);
@@ -393,7 +398,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
             });
         }
 
-        if (this._httpsPort > 0) {
+        if (this._httpPort > 0) {
             if (this._httpServerRunning) {
                 this._httpServerRunning = false;
 
@@ -499,7 +504,7 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
     //
     //
     IsHttpServerRunning() {
-        return this._httpServerRunning || this._httpsPort <= 0;
+        return this._httpServerRunning || this._httpPort <= 0;
     }
     //
     //

--- a/lib/SmartHome.js
+++ b/lib/SmartHome.js
@@ -448,7 +448,8 @@ class GoogleSmartHome extends Aggregation(Auth, Devices, HttpAuth, HttpActions) 
         return {
             httpPort: this._localExecutionPort,
             httpPathPrefix: this.Path_join(this._httpLocalPath, ""),
-            clientId: this._nodeId
+            clientId: this._nodeId,
+            accessToken: this.getLocalAuthCode(),
         }
     }
     //

--- a/local-execution/app.js
+++ b/local-execution/app.js
@@ -63,9 +63,12 @@ const forwardRequest = async (nodeRedData, targetDeviceId, request) => {
     command.requestId = request.requestId;
     command.deviceId = targetDeviceId;
     command.port = nodeRedData.httpPort;
-    command.path = `${nodeRedData.httpPathPrefix}local_smarthome`;
+    command.path = `${nodeRedData.httpPathPrefix}smarthome`;
     command.data = JSON.stringify(request);
     command.dataType = "application/json";
+    command.additionalHeaders = {
+        'Authorization': `Bearer ${nodeRedData.accessToken}`
+    };
     console.log(request.requestId, "Sending", command);
     const deviceManager = await app.getDeviceManager();
 

--- a/local-execution/app.js
+++ b/local-execution/app.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const version = '2.0';
+const version = '2.1';
 
 /// <reference types="@google/local-home-sdk" />
 /*

--- a/test/google-home.json
+++ b/test/google-home.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "home-12345",
+  "private_key_id": "1234567890123456789012345678901234567890",
+  "private_key": "",
+  "client_email": "node-red-request-sync@home-12345.iam.gserviceaccount.com",
+  "client_id": "123456789012345678901",
+  "auth_uri": "https://accounts.testsm.test.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.testsm.test.com/token",
+  "auth_provider_x509_cert_url": "https://www.testsm.test.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.testsm.test.com/robot/v1/metadata/x509/node-red-request-sync%40home-12345.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
Reading the [Local fulfillment documentation](https://developers.google.com/assistant/smarthome/concepts/local) I've read the sentence "No modification of your hardware is expected to integrate local fulfillment.".
In the [Add local fulfillment to your smart home Action documentation](https://developers.google.com/assistant/smarthome/develop/local#update_sync_response_in_the_cloud_fulfillment)  the SYNC response custom data contains the authToken.
Why don't use the authToken field to deliver the access token and use the original smart-home path?
In this way, we have no authenticated path where everyone can send commands to the smart home.

I've added auth token for the local request, this token is updated every time a sync request is received.

Unfortunately, I'm not able to test it completely, because I'm still not able to make the local execution work.
Is someone able to test it?

Thanks


