### PR TITLE
fix: version is not defined

### DIFF
--- a/local-execution/app.js
+++ b/local-execution/app.js
@@ -169,7 +169,7 @@ const queryHandler = async (request) => {
         throw err;
     }
 };
-const app = new App(version);
+const app = new App(VERSION);
 app
     .onIdentify(identifyHandler)
     .onReachableDevices(reachableDevicesHandler)


### PR DESCRIPTION
The previous commit changed  the const "version" in "VERSION" without updating the constructor call

<img width="540" alt="Screenshot 2022-08-03 at 21 08 52" src="https://user-images.githubusercontent.com/9018104/182689955-f4729423-e8ae-4fd4-8d89-1edc094288cd.png">