### PR TITLE
Fix setState don't update the state if the filter topic is enabled

### DIFF
--- a/lib/Devices.js
+++ b/lib/Devices.js
@@ -189,11 +189,11 @@ class Devices {
         Object.keys(states).forEach(deviceId => {
             this._smarthome.debug('Device:setStates(): deviceId = ' + JSON.stringify(deviceId));
             if (Object.prototype.hasOwnProperty.call(me._nodes, deviceId)) {
-                me._nodes[deviceId].onInput({payload: states[deviceId]});
+                me._nodes[deviceId].onInput({topic: me._nodes[deviceId].topicOut, payload: states[deviceId]});
             } else {
                 let id = me.GetIdFromName(deviceId);
                 if (id !== undefined) {
-                    me._nodes[id].onInput({payload: states[deviceId]});
+                    me._nodes[id].onInput({topic: me._nodes[id].topicOut, payload: states[deviceId]});
                 }
             }
         });


### PR DESCRIPTION
If the filter topic is enabled in a node, the setState message sent to a management node don't update the node state.
This PR fixes it.

Claudio
