### PR TITLE
Fix usage of .substring in app.js

### DIFF
--- a/local-execution/app.js
+++ b/local-execution/app.js
@@ -19,7 +19,7 @@ const hex2a = (hexx) => {
     var hex = hexx.toString();
     var str = '';
     for (var i = 0; i < hex.length; i += 2)
-        str += String.fromCharCode(parseInt(hex.substring(i, 2), 16));
+        str += String.fromCharCode(parseInt(hex.substring(i, i+2), 16));
     return str;
 }
 


### PR DESCRIPTION
String.substr was (start, length)
String.substring is (start, end)

This fixes local execution not working on the latest app.js