### PR TITLE
Create Guest Network Password and Number of Connected Devices for Net…

### DIFF
--- a/examples/Guest Network Password and Number of Connected Devices for Network node
+++ b/examples/Guest Network Password and Number of Connected Devices for Network node
@@ -1,0 +1,124 @@
+[
+    {
+        "id": "e36e169834c5f465",
+        "type": "function",
+        "z": "1797c1fc2aa93477",
+        "name": "Format Connected Devices",
+        "func": "msg.payload = {\n    \"numConnectedDevices\" : msg.payload\n}\nreturn msg;",
+        "outputs": 1,
+        "timeout": 0,
+        "noerr": 0,
+        "initialize": "",
+        "finalize": "",
+        "libs": [],
+        "x": 600,
+        "y": 5080,
+        "wires": [
+            [
+                "fc5ed280803811b8"
+            ]
+        ]
+    },
+    {
+        "id": "8155d1fce32f933a",
+        "type": "inject",
+        "z": "1797c1fc2aa93477",
+        "name": "Number Connected Devices",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "48",
+        "payloadType": "num",
+        "x": 300,
+        "y": 5080,
+        "wires": [
+            [
+                "e36e169834c5f465"
+            ]
+        ]
+    },
+    {
+        "id": "fc5ed280803811b8",
+        "type": "debug",
+        "z": "1797c1fc2aa93477",
+        "name": "debug 249",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 850,
+        "y": 5080,
+        "wires": []
+    },
+    {
+        "id": "7bbfe7f6e010da08",
+        "type": "debug",
+        "z": "1797c1fc2aa93477",
+        "name": "debug 250",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 710,
+        "y": 4960,
+        "wires": []
+    },
+    {
+        "id": "9cbef010614ce7e5",
+        "type": "comment",
+        "z": "1797c1fc2aa93477",
+        "name": "README",
+        "info": "In order to display the password for the Guest WIFI Network,\nit is sufficient to inject the data in the Network node. The result is shown on the Google\nNest Hub both as plain text and as a QR code.\n\nOn a Google Mini speaker you will get information that the device\nhas not been setup to support you with the WIFI password.\n\nWhen connected to the (Network) Device node,\nthe debug node may be removed.",
+        "x": 600,
+        "y": 4900,
+        "wires": []
+    },
+    {
+        "id": "57ec09094d896e2d",
+        "type": "comment",
+        "z": "1797c1fc2aa93477",
+        "name": "README",
+        "info": "The user has to insert the number of \"Connected\" devices\nas a numerical value (number).\n\nIt is up to the user to collect the number of devices\n(wired and/or wireless) and insert it in a payload.\n\nThis should be injected as an object in the\nNetwork Device node.\n\nWhen connected to the (Network) Device node,\nthe debug node may be removed.",
+        "x": 600,
+        "y": 5020,
+        "wires": []
+    },
+    {
+        "id": "9d513612fe6e7daf",
+        "type": "inject",
+        "z": "1797c1fc2aa93477",
+        "name": "Password",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": true,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "{\"networkEnabled\":true,\"guestNetworkSettings\":{\"ssid\":\"Your Guest Network SSID\"},\"guestNetworkPassword\":\"Your_Password\"}",
+        "payloadType": "json",
+        "x": 490,
+        "y": 4960,
+        "wires": [
+            [
+                "7bbfe7f6e010da08"
+            ]
+        ]
+    }
+]


### PR DESCRIPTION
…work node

As promised in #479

This PR gives an example how to display the Password of the Guest Network on a Google Nest Hub. It will not give a response on a Google Mini speaker, as these are not setup to respond to this request.

This PR gives also an example how to configure "Connected devices" It will respond to a request on both a Google Mini speaker, as well on a Google Nest Hub. It will not been shown on the display.