### PR TITLE
Use payload.topic if filter topic is enabled

### DIFF
--- a/devices/device.js
+++ b/devices/device.js
@@ -2173,6 +2173,9 @@ module.exports = function (RED) {
                 if(done) done();
                 return;
             }
+            if (me.topic_filter && msg.payload.topic && (msg.topic || '').toString().startsWith(me.topicOut)) {
+                msg.topic = msg.payload.topic;
+            }
             me._debug(".input: topic = " + msg.topic);
 
             let upper_topic = '';


### PR DESCRIPTION
If " Filter incoming messages by topic" is enabled, there is no way to send commands to the node, like the "GetState" or "SetChallengePin" commands.

With this fix, it is possible to use the msg.payload.topic field because the msg.topic must match the configured topic.